### PR TITLE
Add GitHub action setup for ubuntu

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,30 @@
+name: ubuntu
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6.5
+
+      - name: Install bundler
+        run: gem install bundler
+
+      - name: Setup
+        run: bin/setup
+
+      - name: Run tests
+        run: bin/rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
----
-sudo: false
-language: ruby
-cache: bundler
-rvm:
-  - 2.6.3
-before_install: gem install bundler -v 2.0.2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fontist
 
+![ubuntu](https://github.com/fontist/fontist/workflows/ubuntu/badge.svg)
+
 A simple library to find and download fonts for Windows, Linux and Mac.
 
 ## Installation

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,5 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-bundle install
-
-# Do any other automated setup that you need to do here
+gem install bundler --conservative
+bundle check || bundle install

--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
This commit adds the GitHub actions setup to build and run our suite on ubuntu for now. Currently, it only usages one single ruby version to run our test suite.

As soon as the gem is ready then let's also adds other platforms and also add multiple ruby version so we can be sure it's stable in our expected eco-system.