### PR TITLE
Add an interface to find or download a font

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.5
+          ruby-version: 2.6
 
       - name: Install bundler
         run: gem install bundler

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+/assets/*
+!/assets/source.yml
+!/assets/fonts/.keep
 
 # rspec failure tracking
 .rspec_status

--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ gem install fontist
 
 ## Usage
 
-TODO: Coming soon
+### Find a font
+
+The fontist library allows us to easily locate or download a any of the supported
+fonts and then it returns the complete path for the path. To find any font in a
+user's system we can use the following interface.
+
+```ruby
+Fontist::Finder.find("CALIBRI.TTF")
+```
 
 ## Development
 

--- a/assets/source.yml
+++ b/assets/source.yml
@@ -1,0 +1,40 @@
+system:
+  linux:
+    paths:
+      - /usr/share/fonts/truetype/*/*
+
+remote:
+  msvista:
+    fonts:
+      - CALIBRI.TTF
+      - CALIBRII.TTF
+      - CAMBRIA.TTC
+      - CAMBRIAI.TTF
+      - CANDARA.TTF
+      - CANDARAI.TTF
+      - CONSOLA.TTF
+      - CONSOLAI.TTF
+      - CONSTAN.TTF
+      - CONSTANI.TTF
+      - CORBEL.TTF
+      - CORBELI.TTF
+      - MEIRYO.TTC
+      - CALIBRIB.TTF
+      - CALIBRIZ.TTF
+      - CAMBRIAB.TTF
+      - CAMBRIAZ.TTF
+      - CANDARAB.TTF
+      - CANDARAZ.TTF
+      - CONSOLAB.TTF
+      - CONSOLAZ.TTF
+      - CONSTANB.TTF
+      - CONSTANZ.TTF
+      - CORBELB.TTF
+      - CORBELZ.TTF
+      - MEIRYOB.TTC
+
+    file_size: "62914560"
+    sha: "249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423"
+    urls:
+      - "https://www.dropbox.com/s/dl/6lclhxpydwgkjzh/PowerPointViewer.exe?dl=1"
+      - "https://web.archive.org/web/20171225132744/http://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe"

--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -21,6 +21,10 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n")
   spec.test_files    = `git ls-files -- {spec}/*`.split("\n")
 
+  spec.add_runtime_dependency "down", "~> 5.0"
+  spec.add_runtime_dependency "libmspack", "~> 0.1.0"
+
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -1,6 +1,10 @@
+require "libmspack"
 require "fontist/version"
-require "fontist/source"
+
 require "fontist/finder"
+require "fontist/source"
+require "fontist/system_font"
+require "fontist/ms_vista_font"
 
 module Fontist
   class Error < StandardError; end
@@ -11,5 +15,13 @@ module Fontist
 
   def self.root_path
     Pathname.new(File.dirname(__dir__))
+  end
+
+  def self.assets_path
+    Fontist.root_path.join("assets")
+  end
+
+  def self.fonts_path
+    Fontist.assets_path.join("fonts")
   end
 end

--- a/lib/fontist/data/sources.yml
+++ b/lib/fontist/data/sources.yml
@@ -1,3 +1,0 @@
-linux:
-  paths:
-    - /usr/share/fonts/truetype/*/*

--- a/lib/fontist/downloader.rb
+++ b/lib/fontist/downloader.rb
@@ -1,0 +1,69 @@
+require "down"
+require "digest"
+
+module Fontist
+  class Downloader
+    def initialize(file, file_size: nil, sha: nil)
+      @sha = sha
+      @file = file
+      @file_size = file_size || default_file_size
+    end
+
+    def download
+      file = download_file
+      verify_file_checksum(file) || raise_invalid_file
+    end
+
+    def verify_file_checksum(file)
+      file if Digest::SHA256.file(file) === sha
+    end
+
+    def raise_invalid_file
+      raise(Fontist::Error, "Invalid / Tempared file")
+    end
+
+    def self.download(file, options = {})
+      new(file, options).download
+    end
+
+    private
+
+    attr_reader :file, :sha, :file_size
+
+    def default_file_size
+      5 * byte_to_megabyte
+    end
+
+    def byte_to_megabyte
+      @byte_to_megabyte ||= 1024 * 1024
+    end
+
+    def download_path
+      options[:download_path] || Fontist.root_path.join("tmp")
+    end
+
+    def download_file
+      bar = ProgressBar.new(file_size / byte_to_megabyte)
+
+      Down.download(
+        @file,
+        progress_proc: -> (progress) {
+          bar.increment(progress / byte_to_megabyte)
+        }
+      )
+    end
+  end
+
+  class ProgressBar
+    def initialize(total)
+      @counter = 1
+      @total  = total
+    end
+
+    def increment(progress)
+      complete = sprintf("%#.2f%%", ((@counter.to_f / @total.to_f) * 100))
+      print "\r\e[0KDownloads: #{@counter}MB/#{@total}MB (#{complete})"
+      @counter = progress
+    end
+  end
+end

--- a/lib/fontist/ms_vista_font.rb
+++ b/lib/fontist/ms_vista_font.rb
@@ -1,0 +1,67 @@
+require "fontist/downloader"
+
+module Fontist
+  class MsVistaFont
+    def initialize(font_name, fonts_path: nil)
+      @font_name = font_name
+      @fonts_path = fonts_path ||  Fontist.fonts_path
+    end
+
+    def self.fetch_font(font_name, fonts_path: nil)
+      new(font_name, fonts_path: fonts_path).fetch
+    end
+
+    def fetch
+      fonts = extract_ppviewer_fonts
+      fonts.grep(/#{font_name}/)
+    end
+
+    private
+
+    attr_reader :fonts_path, :font_name
+
+    def decompressor
+      @decompressor ||= LibMsPack::CabDecompressor.new
+    end
+
+    def extract_ppviewer_fonts
+      Array.new.tap do |fonts|
+        cabbed_fonts.each do |font|
+          font_path = fonts_path.join(font.filename).to_s
+          decompressor.extract(font, font_path)
+
+          fonts.push(font_path)
+        end
+      end
+    end
+
+    def cabbed_fonts
+      exe_file = decompressor.search(download_exe_file.path)
+      decompressor.extract(exe_file.files.next, ppviewer_cab)
+      grep_cabbed_fonts(decompressor.search(ppviewer_cab).files) || []
+    end
+
+    def grep_cabbed_fonts(file)
+      Array.new.tap do |fonts|
+        while file
+          fonts.push(file) if file.filename.match(/.tt|.TT/)
+          file = file.next
+        end
+      end
+    end
+
+    def source
+      @source ||= Fontist::Source.all.remote.msvista
+    end
+
+    def download_exe_file
+      Fontist::Downloader.download(
+        source.urls.first, file_size: source.file_size.to_i, sha: source.sha
+      )
+    end
+
+    def ppviewer_cab
+      @ppviewer_cab ||= Fontist.assets_path.join("ppviewer.cab").to_s
+    end
+  end
+end

--- a/lib/fontist/source.rb
+++ b/lib/fontist/source.rb
@@ -1,57 +1,31 @@
 require "yaml"
+require "json"
+require "ostruct"
 
 module Fontist
   class Source
-    def initialize(font:, sources: nil)
-      @font = font
-      @user_sources = sources || []
+    def self.all
+      new.all
     end
 
-    def self.find(font, sources: [])
-      new(font: font, sources: sources).find
-    end
-
-    def find
-      paths = user_sources + default_sources["paths"]
-      font_paths = Dir.glob(paths.flatten.uniq)
-
-      font_path = font_paths.select do |font_path|
-        break font_path if font_path.include?(font)
-      end
-
-      font_path unless font_path.empty?
+    def all
+      source_data
     end
 
     private
 
-    attr_reader :font, :user_sources
-
-    def user_os
-      @user_os ||= (
-        host_os = RbConfig::CONFIG["host_os"]
-        case host_os
-        when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
-          :windows
-        when /darwin|mac os/
-          :macosx
-        when /linux/
-          :linux
-        when /solaris|bsd/
-          :unix
-        else
-          raise Fontist::Error, "unknown os: #{host_os.inspect}"
-        end
+    def source_data
+      @source_data ||= JSON.parse(
+        yaml_data.to_json, object_class: OpenStruct
       )
     end
 
-    def source_file
-      @source_file ||= File.open(
-        Fontist.lib_path.join("fontist", "data", "sources.yml"),
-      )
+    def yaml_data
+      YAML.load(File.open(yaml_file))
     end
 
-    def default_sources
-      @default_sources ||= YAML.load(source_file)[user_os.to_s]
+    def yaml_file
+      Fontist.assets_path.join("source.yml")
     end
   end
 end

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -1,0 +1,52 @@
+module Fontist
+  class SystemFont
+    def initialize(font:, sources: nil)
+      @font = font
+      @user_sources = sources || []
+    end
+
+    def self.find(font, sources: [])
+      new(font: font, sources: sources).find
+    end
+
+    def find
+      font_path = font_paths.select do |font_path|
+        break font_path if font_path.include?(font)
+      end
+
+      font_path unless font_path.empty?
+    end
+
+    private
+
+    attr_reader :font, :user_sources
+
+    def font_paths
+      Dir.glob((
+        user_sources + default_sources["paths"]
+      ).flatten.uniq)
+    end
+
+    def default_sources
+      @default_sources ||= Source.all.system[user_os.to_s]
+    end
+
+    def user_os
+      @user_os ||= (
+        host_os = RbConfig::CONFIG["host_os"]
+        case host_os
+        when /mswin|msys|mingw|cygwin|bccwin|wince|emc/
+          :windows
+        when /darwin|mac os/
+          :macosx
+        when /linux/
+          :linux
+        when /solaris|bsd/
+          :unix
+        else
+          raise Fontist::Error, "unknown os: #{host_os.inspect}"
+        end
+      )
+    end
+  end
+end

--- a/spec/fontist/downloader_spec.rb
+++ b/spec/fontist/downloader_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Downloader do
+  describe ".download", api_call: true do
+    it "return the valid downloaded file" do
+      tempfile = Fontist::Downloader.download(
+        sample_file[:file],
+        sha: sample_file[:sha],
+        file_size: sample_file[:file_size],
+      )
+
+      expect(tempfile).not_to be_nil
+      expect(tempfile.size).to eq(sample_file[:file_size])
+    end
+
+    it "raises an error for tempared file" do
+      expect{
+        Fontist::Downloader.download(
+          sample_file[:file],
+          sha: sample_file[:sha] + "mm",
+          file_size: sample_file[:file_size]
+        )
+      }.to raise_error(Fontist::Error, "Invalid / Tempared file")
+    end
+  end
+
+  def sample_file
+    @sample_file ||= {
+      file_size: 10132625,
+      file: "https://unsplash.com/photos/ZXHgEIWELYA/download?force=true",
+      sha: "b701889c51802f6f382206e6d0aa3509c8f98e10f26bd0725ae91d93e148fe7a"
+    }
+  end
+end
+

--- a/spec/fontist/ms_vista_font_spec.rb
+++ b/spec/fontist/ms_vista_font_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+RSpec.describe Fontist::MsVistaFont do
+  describe ".fetch_font", api_call: true  do
+    it "downloads and returns font path" do
+      fonts = Fontist::MsVistaFont.fetch_font("CANDARAI.TTF")
+
+      expect(fonts.count).to eq(1)
+      expect(fonts.first).to include("CANDARAI.TTF")
+    end
+  end
+end

--- a/spec/fontist/source_spec.rb
+++ b/spec/fontist/source_spec.rb
@@ -1,28 +1,13 @@
 require "spec_helper"
 
 RSpec.describe Fontist::Source do
-  describe ".find" do
-    context "with a vlaid existing font" do
-      it "returns the complete font path" do
-        name = "DejaVuSerif.ttf"
-        dejavu_ttf = Fontist::Source.find(name, sources: [font_sources])
+  describe ".all" do
+    it "returns all of the dataset" do
+      sources = Fontist::Source.all
 
-        expect(dejavu_ttf).not_to be_nil
-        expect(dejavu_ttf).to include("spec/fixtures/fonts/")
-      end
+      expect(sources.system.linux.paths).not_to be_nil
+      expect(sources.remote.msvista.file_size).to eq("62914560")
+      expect(sources.remote.msvista.fonts).to include("CALIBRI.TTF")
     end
-
-    context "with invalid font" do
-      it "returns nill to the caller" do
-        name = "invalid-font.ttf"
-        invalid_font = Fontist::Source.find(name, sources: [font_sources])
-
-        expect(invalid_font).to be_nil
-      end
-    end
-  end
-
-  def font_sources
-    @font_sources ||= Fontist.root_path.join("spec/fixtures/fonts/*")
   end
 end

--- a/spec/fontist/system_font_spec.rb
+++ b/spec/fontist/system_font_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+
+RSpec.describe Fontist::SystemFont do
+  describe ".find" do
+    context "with a vlaid existing font" do
+      it "returns the complete font path" do
+        name = "DejaVuSerif.ttf"
+        dejavu_ttf = Fontist::SystemFont.find(name, sources: [font_sources])
+
+        expect(dejavu_ttf).not_to be_nil
+        expect(dejavu_ttf).to include("spec/fixtures/fonts/")
+      end
+    end
+
+    context "with invalid font" do
+      it "returns nill to the caller" do
+        name = "invalid-font.ttf"
+        invalid_font = Fontist::SystemFont.find(name, sources: [font_sources])
+
+        expect(invalid_font).to be_nil
+      end
+    end
+  end
+
+  def font_sources
+    @font_sources ||= Fontist.root_path.join("spec/fixtures/fonts/*")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
+  # Skip the actual API calls by default
+  config.filter_run_excluding api_call: true
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
This commit adds an interface that will allow us to find a font in the user's system. Or even better, if the font is not within user's system but one of our supported font then it will download the font and return the fonts path to the user. Usages:

```ruby
Fontist::Finder.find("CALIBRI.TTF")
```