### PR TITLE
Adjust font lookup and downloading

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,5 @@ require "fontist"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require "irb"
-IRB.start(__FILE__)
+require "pry"
+Pry.start

--- a/lib/fontist/ms_vista_font.rb
+++ b/lib/fontist/ms_vista_font.rb
@@ -2,23 +2,24 @@ require "fontist/downloader"
 
 module Fontist
   class MsVistaFont
-    def initialize(font_name, fonts_path: nil)
+    def initialize(font_name, fonts_path: nil, **options)
       @font_name = font_name
       @fonts_path = fonts_path ||  Fontist.fonts_path
+      @force_download = options.fetch(:force_download, false)
     end
 
-    def self.fetch_font(font_name, fonts_path: nil)
-      new(font_name, fonts_path: fonts_path).fetch
+    def self.fetch_font(font_name, options = {})
+      new(font_name, options).fetch
     end
 
     def fetch
       fonts = extract_ppviewer_fonts
-      fonts.grep(/#{font_name}/)
+      fonts.grep(/#{font_name}/i)
     end
 
     private
 
-    attr_reader :fonts_path, :font_name
+    attr_reader :font_name, :fonts_path, :force_download
 
     def decompressor
       @decompressor ||= LibMsPack::CabDecompressor.new
@@ -35,9 +36,15 @@ module Fontist
       end
     end
 
+    def extract_ppviewer_cab_file
+      if !File.exists?(ppviewer_cab) || force_download
+        exe_file = decompressor.search(download_exe_file.path)
+        decompressor.extract(exe_file.files.next, ppviewer_cab)
+      end
+    end
+
     def cabbed_fonts
-      exe_file = decompressor.search(download_exe_file.path)
-      decompressor.extract(exe_file.files.next, ppviewer_cab)
+      extract_ppviewer_cab_file
       grep_cabbed_fonts(decompressor.search(ppviewer_cab).files) || []
     end
 

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -10,11 +10,7 @@ module Fontist
     end
 
     def find
-      font_path = font_paths.select do |font_path|
-        break font_path if font_path.include?(font)
-      end
-
-      font_path unless font_path.empty?
+      font_paths.grep(/#{font}/i).first
     end
 
     private
@@ -23,7 +19,9 @@ module Fontist
 
     def font_paths
       Dir.glob((
-        user_sources + default_sources["paths"]
+        user_sources +
+        default_sources["paths"] +
+        [Fontist.fonts_path.join("**")]
       ).flatten.uniq)
     end
 

--- a/spec/fontist/finder_spec.rb
+++ b/spec/fontist/finder_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Fontist::Finder do
       it "downloads the fonts and copy to path" do
         name = "CALIBRI.TTF"
         fake_font_path = "./assets/fonts/#{name}"
+        allow(Fontist::SystemFont).to receive(:find).and_return(nil)
 
         allow(Fontist::MsVistaFont).to(
           receive(:fetch_font). and_return(fake_font_path)


### PR DESCRIPTION
Currently, the font lookup is case sensitive, and it also does not use any of the caches. So, this commit changes this and it will try use the case insensitive version for font lookup.

This also usages the cache unless we explicitly specify to download the file again. And, the font lookup also includes the `assets` directory, this will also be used when finding a font.