### PR TITLE
Do not download the font through finder

### DIFF
--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -1,4 +1,5 @@
 require "libmspack"
+require "fontist/errors"
 require "fontist/version"
 
 require "fontist/finder"
@@ -7,8 +8,6 @@ require "fontist/system_font"
 require "fontist/ms_vista_font"
 
 module Fontist
-  class Error < StandardError; end
-
   def self.lib_path
     Fontist.root_path.join("lib")
   end

--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -1,0 +1,6 @@
+module Fontist
+  module Errors
+    class MissingFontError < StandardError; end
+    class NonSupportedFontError < StandardError; end
+  end
+end

--- a/spec/fontist/finder_spec.rb
+++ b/spec/fontist/finder_spec.rb
@@ -12,19 +12,13 @@ RSpec.describe Fontist::Finder do
     end
 
     context "with downloadable ms vista font" do
-      it "downloads the fonts and copy to path" do
+      it "returns missing font error" do
         name = "CALIBRI.TTF"
-        fake_font_path = "./assets/fonts/#{name}"
         allow(Fontist::SystemFont).to receive(:find).and_return(nil)
 
-        allow(Fontist::MsVistaFont).to(
-          receive(:fetch_font). and_return(fake_font_path)
-        )
-
-        calibri_ttf = Fontist::Finder.find(name)
-
-        expect(calibri_ttf).to include(fake_font_path)
-        expect(Fontist::MsVistaFont).to have_received(:fetch_font).with(name)
+        expect {
+          Fontist::Finder.find(name)
+        }.to raise_error(Fontist::Errors::MissingFontError)
       end
     end
 
@@ -34,7 +28,7 @@ RSpec.describe Fontist::Finder do
 
         expect {
           Fontist::Finder.find(font_name)
-        }.to raise_error(Fontist::Error, "Could not find the #{font_name} font")
+        }.to raise_error(Fontist::Errors::NonSupportedFontError)
       end
     end
   end


### PR DESCRIPTION
Currently, the finder interface is doing the job for font lookup and also to download the fonts if missing. But, in reality we need user to accept the font terms, so this commit changes this and it will raise an error for installable fonts instead of downloading it directly.

Later, we will also add suggestion for user on how to download those font from the supported libraries.