### PR TITLE
Add installer to download supported font

### DIFF
--- a/assets/source.yml
+++ b/assets/source.yml
@@ -5,6 +5,8 @@ system:
 
 remote:
   msvista:
+    agreement: "yes"
+
     fonts:
       - CALIBRI.TTF
       - CALIBRII.TTF

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -4,6 +4,7 @@ require "fontist/version"
 
 require "fontist/finder"
 require "fontist/source"
+require "fontist/installer"
 require "fontist/system_font"
 require "fontist/ms_vista_font"
 

--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -1,5 +1,6 @@
 module Fontist
   module Errors
+    class LicensingError < StandardError; end
     class MissingFontError < StandardError; end
     class NonSupportedFontError < StandardError; end
   end

--- a/lib/fontist/finder.rb
+++ b/lib/fontist/finder.rb
@@ -31,7 +31,8 @@ module Fontist
         raise(
           Fontist::Errors::MissingFontError,
           "Fonts are missing, please run" \
-          "Fontist::Installer.install to install these fonts"
+          "Fontist::Installer.download(name, confirmation: 'yes') to " \
+          "download these fonts"
         )
       end
     end

--- a/lib/fontist/installer.rb
+++ b/lib/fontist/installer.rb
@@ -1,0 +1,44 @@
+module Fontist
+  class Installer
+    def initialize(font_name:, confirmation:, **options)
+      @font_name = font_name
+      @confirmation = confirmation.downcase
+      @options = options
+    end
+
+    def download
+      find_system_font || download_font || raise(
+        Fontist::Errors::NonSupportedFontError
+      )
+    end
+
+    def self.download(font_name, confirmation:)
+      new(font_name: font_name, confirmation: confirmation).download
+    end
+
+    private
+
+    attr_reader :font_name, :confirmation, :options
+
+    def downloaders
+      { msvista: Fontist::MsVistaFont }
+    end
+
+    def find_system_font
+      Fontist::SystemFont.find(font_name)
+    end
+
+    def download_font
+      if font_source
+        downloader = downloaders[font_source.first]
+        downloader.fetch_font(font_name, confirmation: confirmation)
+      end
+    end
+
+    def font_source
+      @font_source ||= Fontist::Source.all.remote.to_h.select do |key, value|
+        !value.fonts.grep(/#{font_name}/i).empty?
+      end.first
+    end
+  end
+end

--- a/lib/fontist/ms_vista_font.rb
+++ b/lib/fontist/ms_vista_font.rb
@@ -2,19 +2,25 @@ require "fontist/downloader"
 
 module Fontist
   class MsVistaFont
-    def initialize(font_name, fonts_path: nil, **options)
+    def initialize(font_name, confirmation:, fonts_path: nil, **options)
       @font_name = font_name
+      @confirmation = confirmation || "no"
       @fonts_path = fonts_path ||  Fontist.fonts_path
       @force_download = options.fetch(:force_download, false)
+
+      unless source.agreement === confirmation
+        raise(Fontist::Errors::LicensingError)
+      end
     end
 
-    def self.fetch_font(font_name, options = {})
-      new(font_name, options).fetch
+    def self.fetch_font(font_name, confirmation:, **options)
+      new(font_name, options.merge(confirmation: confirmation)).fetch
     end
 
     def fetch
       fonts = extract_ppviewer_fonts
-      fonts.grep(/#{font_name}/i)
+      paths = fonts.grep(/#{font_name}/i)
+      paths.empty? ? nil : paths
     end
 
     private

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -10,7 +10,8 @@ module Fontist
     end
 
     def find
-      font_paths.grep(/#{font}/i).first
+      paths = font_paths.grep(/#{font}/i)
+      paths.empty? ? nil : paths
     end
 
     private

--- a/spec/fontist/finder_spec.rb
+++ b/spec/fontist/finder_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Fontist::Finder do
         name = "DejaVuSerif.ttf"
         dejavu_ttf = Fontist::Finder.find(name)
 
-        expect(dejavu_ttf).to include(name)
+        expect(dejavu_ttf.first).to include(name)
       end
     end
 

--- a/spec/fontist/installer_spec.rb
+++ b/spec/fontist/installer_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Installer do
+  describe ".download" do
+    context "with already downloaded fonts" do
+      it "returns the font path" do
+        name = "CALIBRI.TTF"
+        Fontist::MsVistaFont.fetch_font(name, confirmation: "yes")
+
+        allow(Fontist::MsVistaFont).to receive(:fetch_font).and_return(nil)
+        paths = Fontist::Installer.download(name, confirmation: "yes")
+
+        expect(paths.first).to include("fonts/#{name}")
+      end
+    end
+
+    context "with missing but downloadable fonts" do
+      it "downloads and install the fonts" do
+        name = "CALIBRI.TTF"
+        confirmation = "yes"
+        allow(Fontist::SystemFont).to receive(:find).and_return(nil)
+
+        paths = Fontist::Installer.download(name, confirmation: confirmation)
+
+        expect(paths.first).to include("fonts/#{name}")
+      end
+
+      it "do not download if user didn't agree" do
+        name = "CALIBRI.TTF"
+        allow(Fontist::SystemFont).to receive(:find).and_return(nil)
+
+        expect {
+          Fontist::Installer.download(name, confirmation: "no")
+        }.to raise_error(Fontist::Errors::LicensingError)
+      end
+    end
+
+    context "with unsupported fonts" do
+      it "raise an unsupported error" do
+        name = "InvalidFont.ttf"
+
+        expect {
+          Fontist::Installer.download(name, confirmation: "yes")
+        }.to raise_error(Fontist::Errors::NonSupportedFontError)
+      end
+    end
+  end
+end

--- a/spec/fontist/ms_vista_font_spec.rb
+++ b/spec/fontist/ms_vista_font_spec.rb
@@ -1,12 +1,27 @@
 require "spec_helper"
 
 RSpec.describe Fontist::MsVistaFont do
-  describe ".fetch_font", api_call: true  do
-    it "downloads and returns font path" do
-      fonts = Fontist::MsVistaFont.fetch_font("CANDARAI.TTF")
+  describe ".fetch_font" do
+    context "with valid licence", api_call: true do
+      it "downloads and returns font paths" do
+        name = "CANDARAI.TTF"
+        fonts = Fontist::MsVistaFont.fetch_font(
+          name, confirmation: "yes", force_download: true
+        )
 
-      expect(fonts.count).to eq(1)
-      expect(fonts.first).to include("CANDARAI.TTF")
+        expect(fonts.count).to eq(1)
+        expect(fonts.first).to include("CANDARAI.TTF")
+      end
+    end
+
+    context "with invalid licence agreement" do
+      it "raise an licensing error" do
+        font_name = "CANDARAI.TTF"
+
+        expect {
+          Fontist::MsVistaFont.fetch_font(font_name, confirmation: "no")
+        }.to raise_error(Fontist::Errors::LicensingError)
+      end
     end
   end
 end

--- a/spec/fontist/system_font_spec.rb
+++ b/spec/fontist/system_font_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Fontist::SystemFont do
         dejavu_ttf = Fontist::SystemFont.find(name, sources: [font_sources])
 
         expect(dejavu_ttf).not_to be_nil
-        expect(dejavu_ttf).to include("spec/fixtures/fonts/")
+        expect(dejavu_ttf.first).to include("spec/fixtures/fonts/")
       end
     end
 


### PR DESCRIPTION
For uninstalled font we want to allow user to download those with proper permission. This commit adds those necessary changes, so now user have a way to utilize `fontist` to download any of the supported fonts. This interface will also return the downloaded paths, so the user can decide what to do with that.