### PR TITLE
Add action to run test suite in windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,32 @@
+name: windows
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          architecture: "x64"
+
+      - name: Setup
+        shell: pwsh
+        run: |
+          gem install bundler
+          bundle config --local path vendor/bundle
+          bundle install --jobs 4 --retry 3
+
+      - name: Run tests
+        run: bundle exec rspec --tag ~skip_in_windows

--- a/assets/source.yml
+++ b/assets/source.yml
@@ -1,6 +1,18 @@
 system:
   linux:
     paths:
+      - /usr/share/fonts/**/**.{ttf,ttc}
+
+  windows:
+    paths:
+      - C:/Windows/Fonts/**/**.{ttc,ttf}
+
+  macosx:
+    paths:
+      - $HOME/Library/Fonts/Microsoft/*/*
+
+  unix:
+    paths:
       - /usr/share/fonts/truetype/*/*
 
 remote:

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -1,4 +1,3 @@
-require "libmspack"
 require "fontist/errors"
 require "fontist/version"
 

--- a/lib/fontist/ms_vista_font.rb
+++ b/lib/fontist/ms_vista_font.rb
@@ -28,7 +28,10 @@ module Fontist
     attr_reader :font_name, :fonts_path, :force_download
 
     def decompressor
-      @decompressor ||= LibMsPack::CabDecompressor.new
+      @decompressor ||= (
+        require "libmspack"
+        LibMsPack::CabDecompressor.new
+      )
     end
 
     def extract_ppviewer_fonts

--- a/spec/fontist/finder_spec.rb
+++ b/spec/fontist/finder_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Fontist::Finder do
     context "with valid font name" do
       it "returns the fonts path" do
         name = "DejaVuSerif.ttf"
+        stub_system_font_finder_to_fixture(name)
         dejavu_ttf = Fontist::Finder.find(name)
 
         expect(dejavu_ttf.first).to include(name)
@@ -31,5 +32,10 @@ RSpec.describe Fontist::Finder do
         }.to raise_error(Fontist::Errors::NonSupportedFontError)
       end
     end
+  end
+
+  def stub_system_font_finder_to_fixture(name)
+    allow(Fontist::SystemFont).to receive(:find).
+      and_return(["spec/fixtures/fonts/#{name}"])
   end
 end

--- a/spec/fontist/installer_spec.rb
+++ b/spec/fontist/installer_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Fontist::Installer do
   describe ".download" do
-    context "with already downloaded fonts" do
+    context "with already downloaded fonts", skip_in_windows: true do
       it "returns the font path" do
         name = "CALIBRI.TTF"
         Fontist::MsVistaFont.fetch_font(name, confirmation: "yes")
@@ -15,7 +15,7 @@ RSpec.describe Fontist::Installer do
     end
 
     context "with missing but downloadable fonts" do
-      it "downloads and install the fonts" do
+      it "downloads and install the fonts", skip_in_windows: true do
         name = "CALIBRI.TTF"
         confirmation = "yes"
         allow(Fontist::SystemFont).to receive(:find).and_return(nil)


### PR DESCRIPTION
This commit adds the github action setup to run the test suite in windows. This commit also adds the correct path for windows font lookup.

Since, all of these fonts are already available in widows so we also skipped the download process for that. But if there are some edge cases then we will also need to take care of those in the future.