### PR TITLE
Add action to run test suite in MacOSX

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -1,0 +1,30 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+
+      - name: Install bundler
+        run: gem install bundler
+
+      - name: Setup
+        run: bin/setup
+
+      - name: Run tests
+        run: bin/rspec

--- a/assets/source.yml
+++ b/assets/source.yml
@@ -9,11 +9,11 @@ system:
 
   macosx:
     paths:
-      - $HOME/Library/Fonts/Microsoft/*/*
+      - /System/Library/Fonts/**/**.{ttf,ttc}
 
   unix:
     paths:
-      - /usr/share/fonts/truetype/*/*
+      - /usr/share/fonts/**/**.{ttf,ttc}
 
 remote:
   msvista:


### PR DESCRIPTION
This commit changes the paths for mac osx font lookup, and this also adds the github action setup to run our test suite in the latest Mac OSX build.

Closes #9 