### PR TITLE
Add a global fonts path for fontist

### DIFF
--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -20,7 +20,11 @@ module Fontist
     Fontist.root_path.join("assets")
   end
 
+  def self.fontist_path
+    Pathname.new(Dir.home).join(".fontist")
+  end
+
   def self.fonts_path
-    Fontist.assets_path.join("fonts")
+    Fontist.fontist_path.join("fonts")
   end
 end

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -3,6 +3,8 @@ module Fontist
     def initialize(font:, sources: nil)
       @font = font
       @user_sources = sources || []
+
+      check_or_create_fontist_path
     end
 
     def self.find(font, sources: [])
@@ -18,12 +20,23 @@ module Fontist
 
     attr_reader :font, :user_sources
 
+    def check_or_create_fontist_path
+      unless fontist_fonts_path.exist?
+        require "fileutils"
+        FileUtils.mkdir_p(fontist_fonts_path)
+      end
+    end
+
     def font_paths
       Dir.glob((
         user_sources +
         default_sources["paths"] +
-        [Fontist.fonts_path.join("**")]
+        [fontist_fonts_path.join("**")]
       ).flatten.uniq)
+    end
+
+    def fontist_fonts_path
+      @fontist_fonts_path ||= Fontist.fonts_path
     end
 
     def default_sources
@@ -47,5 +60,6 @@ module Fontist
         end
       )
     end
+
   end
 end


### PR DESCRIPTION
Currently, each gem version is maintaining a local version for the fonts, which might not be ideal when user will install multiple fontist version. This commit changes this to use a global `.fontist`
directory where it can re-used between multiple versions.