### PR TITLE
Add support for source font formulas

### DIFF
--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "down", "~> 5.0"
   spec.add_runtime_dependency "libmspack", "~> 0.1.0"
+  spec.add_runtime_dependency "rubyzip", "~> 2.3.0"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/fontist/data/formulas/source_font.yml
+++ b/lib/fontist/data/formulas/source_font.yml
@@ -1,0 +1,51 @@
+source_font:
+  agreement: ""
+
+  fonts:
+    - SourceCodePro-Black.ttf
+    - SourceCodePro-BlackIt.ttf
+    - SourceCodePro-Bold.ttf
+    - SourceCodePro-BoldIt.ttf
+    - SourceCodePro-ExtraLight.ttf
+    - SourceCodePro-ExtraLightIt.ttf
+    - SourceCodePro-It.ttf
+    - SourceCodePro-Light.ttf
+    - SourceCodePro-LightIt.ttf
+    - SourceCodePro-Medium.ttf
+    - SourceCodePro-MediumIt.ttf
+    - SourceCodePro-Regular.ttf
+    - SourceCodePro-Semibold
+    - SourceCodePro-SemiboldIt.ttf
+    - SourceSansPro-Black.ttf
+    - SourceSansPro-BlackIt.ttf
+    - SourceSansPro-Bold.ttf
+    - SourceSansPro-BoldIt.ttf
+    - SourceSansPro-ExtraLight.ttf
+    - SourceSansPro-ExtraLightIt.ttf
+    - SourceSansPro-It.ttf
+    - SourceSansPro-Light.ttf
+    - SourceSansPro-LightIt.ttf
+    - SourceSansPro-Medium.ttf
+    - SourceSansPro-MediumIt.ttf
+    - SourceSansPro-Regular.ttf
+    - SourceSansPro-Semibold.ttf
+    - SourceSansPro-SemiboldIt.ttf
+    - SourceSerifPro-Black.ttf
+    - SourceSerifPro-BlackIt.ttf
+    - SourceSerifPro-Bold.ttf
+    - SourceSerifPro-BoldIt.ttf
+    - SourceSerifPro-ExtraLight.ttf
+    - SourceSerifPro-ExtraLightIt.ttf
+    - SourceSerifPro-It.ttf
+    - SourceSerifPro-Light.ttf
+    - SourceSerifPro-LightIt.ttf
+    - SourceSerifPro-Medium.ttf
+    - SourceSerifPro-MediumIt.ttf
+    - SourceSerifPro-Regular.ttf
+    - SourceSerifPro-Semibold.ttf
+    - SourceSerifPro-SemiboldIt.ttf
+
+  file_size: "101440249"
+  sha: "0107b5d4ba305cb4dff2ba19138407aa2153632a2c41592f74d20cd0d0261bfd"
+  urls:
+    - https://github.com/fontist/source-fonts/releases/download/v1.0/source-fonts-1.0.zip

--- a/lib/fontist/data/source.yml
+++ b/lib/fontist/data/source.yml
@@ -18,3 +18,4 @@ system:
 remote:
   formulas:
     - ./formulas/ms_vista.yml
+    - ./formulas/source_font.yml

--- a/lib/fontist/downloader.rb
+++ b/lib/fontist/downloader.rb
@@ -3,9 +3,10 @@ require "digest"
 
 module Fontist
   class Downloader
-    def initialize(file, file_size: nil, sha: nil)
+    def initialize(file, file_size: nil, sha: nil, progress: nil)
       @sha = sha
       @file = file
+      @progress = progress
       @file_size = file_size || default_file_size
     end
 
@@ -19,7 +20,7 @@ module Fontist
     end
 
     def raise_invalid_file
-      raise(Fontist::Error, "Invalid / Tempared file")
+      raise(Fontist::Errors::TemparedFileError)
     end
 
     def self.download(file, options = {})
@@ -48,7 +49,7 @@ module Fontist
       Down.download(
         @file,
         progress_proc: -> (progress) {
-          bar.increment(progress / byte_to_megabyte)
+          bar.increment(progress / byte_to_megabyte) if @progress === true
         }
       )
     end

--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -3,5 +3,6 @@ module Fontist
     class LicensingError < StandardError; end
     class MissingFontError < StandardError; end
     class NonSupportedFontError < StandardError; end
+    class TemparedFileError < StandardError; end
   end
 end

--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -1,4 +1,6 @@
+require "fontist/formulas/base"
 require "fontist/formulas/ms_vista"
+require "fontist/formulas/source_font"
 
 module Fontist
   module Formulas

--- a/lib/fontist/formulas/base.rb
+++ b/lib/fontist/formulas/base.rb
@@ -1,0 +1,25 @@
+module Fontist
+  module Formulas
+    class Base
+      def initialize(font_name, confirmation:, **options)
+        @font_name = font_name
+        @confirmation = confirmation || "no"
+        @force_download = options.fetch(:force_download, false)
+        @fonts_path = options.fetch(:fonts_path, Fontist.fonts_path)
+
+        check_user_license_agreement
+      end
+
+      def self.fetch_font(font_name, confirmation: nil, **options)
+        new(font_name, options.merge(confirmation: confirmation)).fetch
+      end
+
+      private
+
+      attr_reader :font_name, :confirmation, :fonts_path, :force_download
+
+      def check_user_license_agreement
+      end
+    end
+  end
+end

--- a/lib/fontist/formulas/ms_vista.rb
+++ b/lib/fontist/formulas/ms_vista.rb
@@ -2,22 +2,7 @@ require "fontist/downloader"
 
 module Fontist
   module Formulas
-    class MsVista
-      def initialize(font_name, confirmation:, fonts_path: nil, **options)
-        @font_name = font_name
-        @confirmation = confirmation || "no"
-        @fonts_path = fonts_path ||  Fontist.fonts_path
-        @force_download = options.fetch(:force_download, false)
-
-        unless source.agreement === confirmation
-          raise(Fontist::Errors::LicensingError)
-        end
-      end
-
-      def self.fetch_font(font_name, confirmation:, **options)
-        new(font_name, options.merge(confirmation: confirmation)).fetch
-      end
-
+    class MsVista < Base
       def fetch
         fonts = extract_ppviewer_fonts
         paths = fonts.grep(/#{font_name}/i)
@@ -26,7 +11,11 @@ module Fontist
 
       private
 
-      attr_reader :font_name, :fonts_path, :force_download
+      def check_user_license_agreement
+        unless source.agreement === confirmation
+          raise(Fontist::Errors::LicensingError)
+        end
+      end
 
       def decompressor
         @decompressor ||= (

--- a/lib/fontist/formulas/source_font.rb
+++ b/lib/fontist/formulas/source_font.rb
@@ -1,0 +1,48 @@
+require "zip"
+
+module Fontist
+  module Formulas
+    class SourceFont < Formulas::Base
+      def fetch
+        paths = extract_fonts.grep(/#{font_name}/i)
+        paths.empty? ? nil : paths
+      end
+
+      private
+
+      def source
+        @source ||= Fontist::Source.formulas.source_font
+      end
+
+      def extract_fonts
+        zip_file = download_file
+        unzip_fonts(zip_file)
+      end
+
+      def unzip_fonts(file)
+        Zip.on_exists_proc = true
+
+        Array.new.tap do |fonts|
+          Zip::File.open(file) do |zip_file|
+            zip_file.glob("fonts/*.ttf").each do |entry|
+              filename = entry.name.gsub("fonts/", "")
+
+              if filename
+                font_path = fonts_path.join(filename)
+                fonts.push(font_path.to_s)
+
+                entry.extract(font_path)
+              end
+            end
+          end
+        end
+      end
+
+      def download_file
+        Fontist::Downloader.download(
+          source.urls.first, file_size: source.file_size.to_i, sha: source.sha
+        )
+      end
+    end
+  end
+end

--- a/lib/fontist/installer.rb
+++ b/lib/fontist/installer.rb
@@ -21,7 +21,10 @@ module Fontist
     attr_reader :font_name, :confirmation, :options
 
     def downloaders
-      { msvista: Fontist::Formulas::MsVista }
+      {
+        msvista: Fontist::Formulas::MsVista,
+        source_front: Fontist::Formulas::SourceFont,
+      }
     end
 
     def find_system_font

--- a/spec/fontist/downloader_spec.rb
+++ b/spec/fontist/downloader_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
-
 RSpec.describe Fontist::Downloader do
-  describe ".download", api_call: true do
+  describe ".download", file_download: true do
     it "return the valid downloaded file" do
       tempfile = Fontist::Downloader.download(
         sample_file[:file],
@@ -20,15 +19,15 @@ RSpec.describe Fontist::Downloader do
           sha: sample_file[:sha] + "mm",
           file_size: sample_file[:file_size]
         )
-      }.to raise_error(Fontist::Error, "Invalid / Tempared file")
+      }.to raise_error(Fontist::Errors::TemparedFileError)
     end
   end
 
   def sample_file
     @sample_file ||= {
-      file_size: 10132625,
-      file: "https://unsplash.com/photos/ZXHgEIWELYA/download?force=true",
-      sha: "b701889c51802f6f382206e6d0aa3509c8f98e10f26bd0725ae91d93e148fe7a"
+      file_size: 150899,
+      file: "https://drive.google.com/u/0/uc?id=1Kk-rpLyQk98ubgxhTRKD2ZkMoY9KqKXk&export=download",
+      sha: "5e513e4bfdada0ff10dd5b96414fcaeade84e235ce043865416ad7673cb6f3d8"
     }
   end
 end

--- a/spec/fontist/formulas/ms_vista_spec.rb
+++ b/spec/fontist/formulas/ms_vista_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Fontist::Formulas::MsVista do
   describe ".fetch_font" do
-    context "with valid licence", api_call: true do
+    context "with valid licence", file_download: true do
       it "downloads and returns font paths" do
         name = "CANDARAI.TTF"
         fonts = Fontist::Formulas::MsVista.fetch_font(

--- a/spec/fontist/formulas/source_font_spec.rb
+++ b/spec/fontist/formulas/source_font_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas::SourceFont do
+  describe ".fetch_font" do
+    it "downloads and extract out fonts", file_download: true do
+      name = "SourceCodePro"
+      stub_fontist_path_to_assets
+
+      fonts = Fontist::Formulas::SourceFont.fetch_font(
+        name, confirmation: "yes", force_download: true,
+      )
+
+      expect(fonts).not_to be_empty
+      expect(fonts.first).to include(name)
+      expect(Fontist::Finder.find(name)).not_to be_empty
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,18 @@
 require "bundler/setup"
 require "fontist"
 
+Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
+  config.include Fontist::Helper
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
-  # Skip the actual API calls by default
-  config.filter_run_excluding api_call: true
+  # Skip the actual file_download by default
+  config.filter_run_excluding file_download: true
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/support/fontist_helper.rb
+++ b/spec/support/fontist_helper.rb
@@ -1,0 +1,8 @@
+module Fontist
+  module Helper
+    def stub_fontist_path_to_assets
+      allow(Fontist).to receive(:fontist_path).and_return(Fontist.assets_path)
+    end
+  end
+end
+


### PR DESCRIPTION
This commit adds the support for source font formulas, you can find supported font list `lib/fontist/data/forumlas/source**`. So, now it will download and extract source fonts if necessary.