### PR TITLE
Add support for microsoft's true types

### DIFF
--- a/lib/fontist/data/formulas/ms_system.yml
+++ b/lib/fontist/data/formulas/ms_system.yml
@@ -1,0 +1,29 @@
+ms_system:
+  agreement: "yes"
+
+  fonts:
+    - Arial.ttf
+    - ArialBd.ttf
+    - ArialI.ttf
+    - ArialBI.ttf
+    - Times.ttf
+    - TimesBd.ttf
+    - TimesI.ttf
+    - TimesBI.ttf
+    - Verdana.ttf
+    - Verdanai.ttf
+    - Verdanab.ttf
+    - Verdanaz.ttf
+    - trebuc.ttf
+    - trebucbi.ttf
+    - trebucbd.ttf
+    - trebucit.ttf
+
+  file_size: "1675184"
+  sha: "464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8"
+  urls:
+    - https://download.microsoft.com/download/a/1/8/a180e21e-9c2b-4b54-9c32-bf7fd7429970/EUupdate.EXE
+    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/EUupdate.EXE
+
+  licence: |
+    Details license goes here

--- a/lib/fontist/data/source.yml
+++ b/lib/fontist/data/source.yml
@@ -18,4 +18,5 @@ system:
 remote:
   formulas:
     - ./formulas/ms_vista.yml
+    - ./formulas/ms_system.yml
     - ./formulas/source_font.yml

--- a/lib/fontist/downloader.rb
+++ b/lib/fontist/downloader.rb
@@ -7,7 +7,7 @@ module Fontist
       @sha = sha
       @file = file
       @progress = progress
-      @file_size = file_size || default_file_size
+      @file_size = (file_size || default_file_size).to_i
     end
 
     def download

--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -1,5 +1,6 @@
 require "fontist/formulas/base"
 require "fontist/formulas/ms_vista"
+require "fontist/formulas/ms_system"
 require "fontist/formulas/source_font"
 
 module Fontist

--- a/lib/fontist/formulas/ms_system.rb
+++ b/lib/fontist/formulas/ms_system.rb
@@ -1,0 +1,62 @@
+module Fontist
+  module Formulas
+    class MsSystem < Base
+      def fetch
+        fonts = extract_cabbed_fonts
+        paths = fonts.grep(/#{font_name}/i)
+        paths.empty? ? nil : paths
+      end
+
+      private
+
+      def check_user_license_agreement
+        unless source.agreement === confirmation
+          raise(Fontist::Errors::LicensingError)
+        end
+      end
+
+      def decompressor
+        @decompressor ||= (
+          require "libmspack"
+          LibMsPack::CabDecompressor.new
+        )
+      end
+
+      def extract_cabbed_fonts
+        Array.new.tap do |fonts|
+          cabbed_fonts.each do |font|
+            font_path = fonts_path.join(font.filename).to_s
+            decompressor.extract(font, font_path)
+
+            fonts.push(font_path)
+          end
+        end
+      end
+
+      def cabbed_fonts
+        exe_file = download_exe_file
+        cab_file = decompressor.search(exe_file.path)
+        grep_cabbed_fonts(cab_file.files) || []
+      end
+
+      def grep_cabbed_fonts(file)
+        Array.new.tap do |fonts|
+          while file
+            fonts.push(file) if file.filename.match(/.tt|.ttc/i)
+            file = file.next
+          end
+        end
+      end
+
+      def source
+        @source ||= Fontist::Source.formulas.ms_system
+      end
+
+      def download_exe_file
+        Fontist::Downloader.download(
+          source.urls.first, file_size: source.file_size, sha: source.sha,
+        )
+      end
+    end
+  end
+end

--- a/lib/fontist/installer.rb
+++ b/lib/fontist/installer.rb
@@ -23,6 +23,7 @@ module Fontist
     def downloaders
       {
         msvista: Fontist::Formulas::MsVista,
+        ms_system: Fontist::Formulas::MsSystem,
         source_front: Fontist::Formulas::SourceFont,
       }
     end

--- a/spec/fontist/formulas/ms_system_spec.rb
+++ b/spec/fontist/formulas/ms_system_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas::MsSystem do
+  describe ".fetch_font" do
+    context "with valid licence", file_download: true do
+      it "downloads and returns font paths" do
+        name = "Times"
+        stub_fontist_path_to_assets
+
+        fonts = Fontist::Formulas::MsSystem.fetch_font(
+          name, confirmation: "yes"
+        )
+
+        expect(fonts).not_to be_empty
+        expect(fonts.first).to include(name)
+        expect(Fontist::Finder.find(name)).not_to be_empty
+      end
+    end
+
+    context "with invalid licence agreement" do
+      it "raise an licensing error" do
+        font_name = "Times"
+        stub_fontist_path_to_assets
+
+        expect {
+          Fontist::Formulas::MsSystem.fetch_font(font_name, confirmation: "no")
+        }.to raise_error(Fontist::Errors::LicensingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the support for Microsfot's true type fonts, and this includes `Arial`, `Times`, `Verdana` and the `trebuc`. We do not have support for font styles yet, so looking for the `Times` will return all available font's for that style.