### PR TITLE
Add support for the courier fonts

### DIFF
--- a/lib/fontist/data/formulas/courier.yml
+++ b/lib/fontist/data/formulas/courier.yml
@@ -1,0 +1,17 @@
+courier:
+  agreement: "yes"
+
+  fonts:
+    - cour.ttf
+    - couri.ttf
+    - courbd.ttf
+    - courbi.ttf
+
+  file_size: "1675184"
+  sha: "bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384"
+  urls:
+    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/courie32.exe
+    - http://sft.if.usp.br/msttcorefonts/courie32.exe
+
+  licence: |
+    Details of the license goes here.

--- a/lib/fontist/data/source.yml
+++ b/lib/fontist/data/source.yml
@@ -20,3 +20,4 @@ remote:
     - ./formulas/ms_vista.yml
     - ./formulas/ms_system.yml
     - ./formulas/source_font.yml
+    - ./formulas/courier.yml

--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -2,6 +2,7 @@ require "fontist/formulas/base"
 require "fontist/formulas/ms_vista"
 require "fontist/formulas/ms_system"
 require "fontist/formulas/source_font"
+require "fontist/formulas/courier_font"
 
 module Fontist
   module Formulas

--- a/lib/fontist/formulas/base.rb
+++ b/lib/fontist/formulas/base.rb
@@ -2,6 +2,7 @@ module Fontist
   module Formulas
     class Base
       def initialize(font_name, confirmation:, **options)
+        @matched_fonts = []
         @font_name = font_name
         @confirmation = confirmation || "no"
         @force_download = options.fetch(:force_download, false)
@@ -14,11 +15,82 @@ module Fontist
         new(font_name, options.merge(confirmation: confirmation)).fetch
       end
 
+      def fetch
+        extract_fonts([font_name])
+        matched_fonts_uniq = matched_fonts.flatten.uniq
+
+        matched_fonts_uniq.empty? ? nil : matched_fonts_uniq
+      end
+
       private
 
-      attr_reader :font_name, :confirmation, :fonts_path, :force_download
+      attr_reader(
+        :font_name,
+        :fonts_path,
+        :confirmation,
+        :matched_fonts,
+        :force_download,
+      )
 
       def check_user_license_agreement
+      end
+
+      def resources(name, &block)
+        source = formulas[name]
+        block_given? ? yield(source) : source
+      end
+
+      def decompressor
+        @decompressor ||= (
+          require "libmspack"
+          LibMsPack::CabDecompressor.new
+        )
+      end
+
+      def formulas
+        @formulas ||= Fontist::Source.formulas
+      end
+
+      def match_fonts(fonts_dir, font_name)
+        font = fonts_dir.grep(/#{font_name}/i)
+        @matched_fonts.push(font) if font
+
+        font
+      end
+
+      def cab_extract(resource, font_ext = /.tt|.ttc/i)
+        exe_file = download_file(resource)
+        cab_file = decompressor.search(exe_file.path)
+        cabbed_fonts = grep_fonts(cab_file.files, font_ext) || []
+        fonts_paths = extract_cabbed_fonts_to_assets(cabbed_fonts)
+
+        yield(fonts_paths) if block_given?
+      end
+
+      def grep_fonts(file, font_ext)
+        Array.new.tap do |fonts|
+          while file
+            fonts.push(file) if file.filename.match(font_ext)
+            file = file.next
+          end
+        end
+      end
+
+      def extract_cabbed_fonts_to_assets(cabbed_fonts)
+        Array.new.tap do |fonts|
+          cabbed_fonts.each do |font|
+            font_path = fonts_path.join(font.filename).to_s
+            decompressor.extract(font, font_path)
+
+            fonts.push(font_path)
+          end
+        end
+      end
+
+      def download_file(source)
+        Fontist::Downloader.download(
+          source.urls.first, sha: source.sha, file_size: source.file_size,
+        )
       end
     end
   end

--- a/lib/fontist/formulas/courier_font.rb
+++ b/lib/fontist/formulas/courier_font.rb
@@ -1,0 +1,23 @@
+module Fontist
+  module Formulas
+    class CourierFont < Base
+      private
+
+      def extract_fonts(font_names)
+        resources("courier") do |resource|
+          cab_extract(resource) do |fonts_dir|
+            font_names.each do |font_name|
+              match_fonts(fonts_dir, font_name)
+            end
+          end
+        end
+      end
+
+      def check_user_license_agreement
+        unless resources("courier").agreement === confirmation
+          raise(Fontist::Errors::LicensingError)
+        end
+      end
+    end
+  end
+end

--- a/spec/fontist/formulas/courier_font_spec.rb
+++ b/spec/fontist/formulas/courier_font_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas::CourierFont do
+  describe ".fetch_font" do
+    context "with valid licence", skip_in_windows: true do
+      it "downloads and returns the fonts", file_download: true do
+        name = "cour"
+        stub_fontist_path_to_assets
+        fonts = Fontist::Formulas::CourierFont.fetch_font(
+          name, confirmation: "yes", force_download: true
+        )
+
+        expect(fonts.count).to eq(4)
+        expect(fonts.first).to include(name)
+        expect(Fontist::Finder.find(name)).not_to be_empty
+      end
+    end
+
+    context "with invalid licence agreement" do
+      it "raise an licensing error" do
+        font_name = "cour"
+        stub_fontist_path_to_assets
+
+        expect {
+          Fontist::Formulas::CourierFont.fetch_font(font_name, confirmation: "no")
+        }.to raise_error(Fontist::Errors::LicensingError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds support for the courier fonts, so now user can look for any of the courier fonts and also download those when necessary. This commit also extract out some behavior so that could be helpful for the future approach for formulas.