### PR TITLE
Adopt new structure for source fonts

### DIFF
--- a/lib/fontist/data/formulas/source_font.yml
+++ b/lib/fontist/data/formulas/source_font.yml
@@ -14,8 +14,15 @@ source_font:
     - SourceCodePro-Medium.ttf
     - SourceCodePro-MediumIt.ttf
     - SourceCodePro-Regular.ttf
-    - SourceCodePro-Semibold
+    - SourceCodePro-Semibold.ttf
     - SourceCodePro-SemiboldIt.ttf
+    - SourceHanSans-Bold.ttc
+    - SourceHanSans-ExtraLight.ttc
+    - SourceHanSans-Heavy.ttc
+    - SourceHanSans-Light.ttc
+    - SourceHanSans-Medium.ttc
+    - SourceHanSans-Normal.ttc
+    - SourceHanSans-Regular.ttc
     - SourceSansPro-Black.ttf
     - SourceSansPro-BlackIt.ttf
     - SourceSansPro-Bold.ttf
@@ -25,8 +32,6 @@ source_font:
     - SourceSansPro-It.ttf
     - SourceSansPro-Light.ttf
     - SourceSansPro-LightIt.ttf
-    - SourceSansPro-Medium.ttf
-    - SourceSansPro-MediumIt.ttf
     - SourceSansPro-Regular.ttf
     - SourceSansPro-Semibold.ttf
     - SourceSansPro-SemiboldIt.ttf
@@ -39,8 +44,6 @@ source_font:
     - SourceSerifPro-It.ttf
     - SourceSerifPro-Light.ttf
     - SourceSerifPro-LightIt.ttf
-    - SourceSerifPro-Medium.ttf
-    - SourceSerifPro-MediumIt.ttf
     - SourceSerifPro-Regular.ttf
     - SourceSerifPro-Semibold.ttf
     - SourceSerifPro-SemiboldIt.ttf

--- a/lib/fontist/formulas/courier_font.rb
+++ b/lib/fontist/formulas/courier_font.rb
@@ -1,6 +1,8 @@
 module Fontist
   module Formulas
     class CourierFont < Base
+      include Formulas::Helpers::ExeExtractor
+
       private
 
       def extract_fonts(font_names)

--- a/lib/fontist/formulas/helpers/exe_extractor.rb
+++ b/lib/fontist/formulas/helpers/exe_extractor.rb
@@ -1,0 +1,45 @@
+module Fontist
+  module Formulas
+    module Helpers
+      module ExeExtractor
+        def cab_extract(exe_file, download: true,  font_ext: /.tt|.ttc/i)
+          exe_file = download_file(exe_file).path if download
+          cab_file = decompressor.search(exe_file)
+          cabbed_fonts = grep_fonts(cab_file.files, font_ext) || []
+          fonts_paths = extract_cabbed_fonts_to_assets(cabbed_fonts)
+
+          yield(fonts_paths) if block_given?
+        end
+
+        private
+
+        def decompressor
+          @decompressor ||= (
+            require "libmspack"
+            LibMsPack::CabDecompressor.new
+          )
+        end
+
+        def grep_fonts(file, font_ext)
+          Array.new.tap do |fonts|
+            while file
+              fonts.push(file) if file.filename.match(font_ext)
+              file = file.next
+            end
+          end
+        end
+
+        def extract_cabbed_fonts_to_assets(cabbed_fonts)
+          Array.new.tap do |fonts|
+            cabbed_fonts.each do |font|
+              font_path = fonts_path.join(font.filename).to_s
+              decompressor.extract(font, font_path)
+
+              fonts.push(font_path)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontist/formulas/helpers/zip_extractor.rb
+++ b/lib/fontist/formulas/helpers/zip_extractor.rb
@@ -1,0 +1,36 @@
+module Fontist
+  module Formulas
+    module Helpers
+      module ZipExtractor
+        def zip_extract(resource, download: true, fonts_sub_dir: "/")
+          zip_file = download_file(resource) if download
+          zip_file ||= resource.urls.first
+
+          fonts_paths = unzip_fonts(zip_file, fonts_sub_dir)
+          block_given? ? yield(fonts_paths) : fonts_paths
+        end
+
+        private
+
+        def unzip_fonts(file, fonts_sub_dir = "/")
+          Zip.on_exists_proc = true
+
+          Array.new.tap do |fonts|
+            Zip::File.open(file) do |zip_file|
+              zip_file.glob("#{fonts_sub_dir}*.{ttf,ttc}").each do |entry|
+                filename = entry.name.gsub("#{fonts_sub_dir}", "")
+
+                if filename
+                  font_path = fonts_path.join(filename)
+                  fonts.push(font_path.to_s)
+
+                  entry.extract(font_path)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fontist/formulas/ms_system.rb
+++ b/lib/fontist/formulas/ms_system.rb
@@ -1,6 +1,8 @@
 module Fontist
   module Formulas
     class MsSystem < Base
+      include Formulas::Helpers::ExeExtractor
+
       private
 
       def data_node

--- a/lib/fontist/formulas/ms_vista.rb
+++ b/lib/fontist/formulas/ms_vista.rb
@@ -1,8 +1,8 @@
-require "fontist/downloader"
-
 module Fontist
   module Formulas
     class MsVista < Base
+      include Formulas::Helpers::ExeExtractor
+
       private
 
       def data_node

--- a/lib/fontist/formulas/source_font.rb
+++ b/lib/fontist/formulas/source_font.rb
@@ -3,45 +3,22 @@ require "zip"
 module Fontist
   module Formulas
     class SourceFont < Formulas::Base
-      def fetch
-        paths = extract_fonts.grep(/#{font_name}/i)
-        paths.empty? ? nil : paths
-      end
+      include Formulas::Helpers::ZipExtractor
 
       private
 
-      def source
-        @source ||= Fontist::Source.formulas.source_font
+      def data_node
+        @data_node ||= "source_font"
       end
 
-      def extract_fonts
-        zip_file = download_file
-        unzip_fonts(zip_file)
-      end
-
-      def unzip_fonts(file)
-        Zip.on_exists_proc = true
-
-        Array.new.tap do |fonts|
-          Zip::File.open(file) do |zip_file|
-            zip_file.glob("fonts/*.ttf").each do |entry|
-              filename = entry.name.gsub("fonts/", "")
-
-              if filename
-                font_path = fonts_path.join(filename)
-                fonts.push(font_path.to_s)
-
-                entry.extract(font_path)
-              end
+      def extract_fonts(font_names)
+        resources(data_node) do |resource|
+          zip_extract(resource, fonts_sub_dir: "fonts/") do |fonts_paths|
+            font_names.each do |font_name|
+              match_fonts(fonts_paths, font_name)
             end
           end
         end
-      end
-
-      def download_file
-        Fontist::Downloader.download(
-          source.urls.first, file_size: source.file_size.to_i, sha: source.sha
-        )
       end
     end
   end


### PR DESCRIPTION
Earlier, we were using zip extraction & everything else on the source font itself. But now that we started implementing a new formula structure, so this commit migrates the zip extractions
to a separate concern, so it's only one place where we'll need to change in the future.

This also extract out some non common behaviors, like: Exe, or Zip extraction to separate helper module, so now each formula doesn't need to include everything but only pick the one they need for them.