### PR TITLE
Add support for meta data for fonts

### DIFF
--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -6,6 +6,7 @@ require "fontist/source"
 require "fontist/installer"
 require "fontist/system_font"
 require "fontist/formulas"
+require "fontist/formula_finder"
 
 module Fontist
   def self.lib_path

--- a/lib/fontist/data/formulas/courier.yml
+++ b/lib/fontist/data/formulas/courier.yml
@@ -2,10 +2,19 @@ courier:
   agreement: "yes"
 
   fonts:
-    - cour.ttf
-    - couri.ttf
-    - courbd.ttf
-    - courbi.ttf
+    - name: Courier
+      styles:
+        - type: Regular
+          font: cour.ttf
+
+        - type: Bold
+          font: courbd.ttf
+
+        - type: Italic
+          font: couri.ttf
+
+        - type: Bold Italic
+          font: courbi.ttf
 
   file_size: "1675184"
   sha: "bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384"

--- a/lib/fontist/data/formulas/ms_system.yml
+++ b/lib/fontist/data/formulas/ms_system.yml
@@ -2,22 +2,61 @@ ms_system:
   agreement: "yes"
 
   fonts:
-    - Arial.ttf
-    - ArialBd.ttf
-    - ArialI.ttf
-    - ArialBI.ttf
-    - Times.ttf
-    - TimesBd.ttf
-    - TimesI.ttf
-    - TimesBI.ttf
-    - Verdana.ttf
-    - Verdanai.ttf
-    - Verdanab.ttf
-    - Verdanaz.ttf
-    - trebuc.ttf
-    - trebucbi.ttf
-    - trebucbd.ttf
-    - trebucit.ttf
+    - name: Arial
+      styles:
+        - type: Regular
+          font: Arial.ttf
+
+        - type: Bold
+          font: ArialBd.ttf
+
+        - type: Italic
+          font: ArialBd.ttf
+
+        - type: Bold Italic
+          font: ArialBI.ttf
+
+    - name: Times New Roman
+      styles:
+        - type: Regular
+          font: Times.ttf
+
+        - type: Bold
+          font: TimesBd.ttf
+
+        - type: Italic
+          font: TimesI.ttf
+
+        - type: Bold Italic
+          font: TimesBI.ttf
+
+    - name: Verdana
+      styles:
+        - type: Regular
+          font: Verdana.ttf
+
+        - type: Bold
+          font: Verdanab.ttf
+
+        - type: Italic
+          font: Verdanai.ttf
+
+        - type: Bold Italic
+          font: Verdanaz.ttf
+
+    - name: Trebuchet
+      styles:
+        - type: Regular
+          font: trebuc.ttf
+
+        - type: Bold
+          font: trebucbd.ttf
+
+        - type: Italic
+          font: trebucit.ttf
+
+        - type: Bold Italic
+          font: trebucbi.ttf
 
   file_size: "1675184"
   sha: "464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8"

--- a/lib/fontist/data/formulas/ms_vista.yml
+++ b/lib/fontist/data/formulas/ms_vista.yml
@@ -2,32 +2,111 @@ msvista:
   agreement: "yes"
 
   fonts:
-    - CALIBRI.TTF
-    - CALIBRII.TTF
-    - CAMBRIA.TTC
-    - CAMBRIAI.TTF
-    - CANDARA.TTF
-    - CANDARAI.TTF
-    - CONSOLA.TTF
-    - CONSOLAI.TTF
-    - CONSTAN.TTF
-    - CONSTANI.TTF
-    - CORBEL.TTF
-    - CORBELI.TTF
-    - MEIRYO.TTC
-    - CALIBRIB.TTF
-    - CALIBRIZ.TTF
-    - CAMBRIAB.TTF
-    - CAMBRIAZ.TTF
-    - CANDARAB.TTF
-    - CANDARAZ.TTF
-    - CONSOLAB.TTF
-    - CONSOLAZ.TTF
-    - CONSTANB.TTF
-    - CONSTANZ.TTF
-    - CORBELB.TTF
-    - CORBELZ.TTF
-    - MEIRYOB.TTC
+    - name: Cambria
+      styles:
+        - type: Regular
+          font: CAMBRIA.TTC
+
+        - type: Bold
+          font: CAMBRIAB.TTF
+
+        - type: Italic
+          font: CAMBRIAI.TTF
+
+        - type: Bold Italic
+          font: CAMBRIAZ.TTF
+
+    - name: Calibri
+      styles:
+        - type: Regular
+          font: CALIBRI.TTF
+
+        - type: Bold
+          font: CALIBRIB.TTF
+
+        - type: Italic
+          font: CALIBRII.TTF
+
+        - type: Bold Italic
+          font: CALIBRIZ.TTF
+
+    - name: Candara
+      styles:
+        - type: Regular
+          font: CANDARA.TTF
+
+        - type: Bold
+          font: CANDARAB.TTF
+
+        - type: Italic
+          font: CANDARAI.TTF
+
+        - type: Bold Italic
+          font: CANDARAZ.TTF
+
+    - name: Consola
+      styles:
+        - type: Regular
+          font: CONSOLA.TTF
+
+        - type: Bold
+          font: CONSOLAB.TTF
+
+        - type: Italic
+          font: CONSOLAI.TTF
+
+        - type: Bold Italic
+          font: CONSOLAZ.TTF
+
+    - name: Constantia
+      styles:
+        - type: Regular
+          font: CONSTAN.TTF
+
+        - type: Bold
+          font: CONSTANB.TTF
+
+        - type: Italic
+          font: CONSTANI.TTF
+
+        - type: Bold Italic
+          font: CONSTANZ.TTF
+
+    - name: Corbel
+      styles:
+        - type: Regular
+          font: CORBEL.TTF
+
+        - type: Bold
+          font: CORBELB.TTF
+
+        - type: Italic
+          font: CORBELI.TTF
+
+        - type: Bold Italic
+          font: CORBELZ.TTF
+
+    # Note: further work necessary
+    #
+    # The initial version is returing the ttc fonts as
+    # it is, but maybe in the upcoming releases we will need
+    # to extract/parse the ttc fonts if necessary.
+    #
+    - name: Meiryo
+      styles:
+        - type: Regular
+          font: MEIRYO.TTC
+
+        - type: Bold
+          font: MEIRYO.TTC
+
+    - name: Meiryo UI
+      styles:
+        - type: Regular
+          font: MEIRYO.TTC
+
+        - type: Bold
+          font: MEIRYO.TTC
 
   file_size: "62914560"
   sha: "249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423"

--- a/lib/fontist/data/formulas/source_font.yml
+++ b/lib/fontist/data/formulas/source_font.yml
@@ -2,51 +2,160 @@ source_font:
   agreement: ""
 
   fonts:
-    - SourceCodePro-Black.ttf
-    - SourceCodePro-BlackIt.ttf
-    - SourceCodePro-Bold.ttf
-    - SourceCodePro-BoldIt.ttf
-    - SourceCodePro-ExtraLight.ttf
-    - SourceCodePro-ExtraLightIt.ttf
-    - SourceCodePro-It.ttf
-    - SourceCodePro-Light.ttf
-    - SourceCodePro-LightIt.ttf
-    - SourceCodePro-Medium.ttf
-    - SourceCodePro-MediumIt.ttf
-    - SourceCodePro-Regular.ttf
-    - SourceCodePro-Semibold.ttf
-    - SourceCodePro-SemiboldIt.ttf
-    - SourceHanSans-Bold.ttc
-    - SourceHanSans-ExtraLight.ttc
-    - SourceHanSans-Heavy.ttc
-    - SourceHanSans-Light.ttc
-    - SourceHanSans-Medium.ttc
-    - SourceHanSans-Normal.ttc
-    - SourceHanSans-Regular.ttc
-    - SourceSansPro-Black.ttf
-    - SourceSansPro-BlackIt.ttf
-    - SourceSansPro-Bold.ttf
-    - SourceSansPro-BoldIt.ttf
-    - SourceSansPro-ExtraLight.ttf
-    - SourceSansPro-ExtraLightIt.ttf
-    - SourceSansPro-It.ttf
-    - SourceSansPro-Light.ttf
-    - SourceSansPro-LightIt.ttf
-    - SourceSansPro-Regular.ttf
-    - SourceSansPro-Semibold.ttf
-    - SourceSansPro-SemiboldIt.ttf
-    - SourceSerifPro-Black.ttf
-    - SourceSerifPro-BlackIt.ttf
-    - SourceSerifPro-Bold.ttf
-    - SourceSerifPro-BoldIt.ttf
-    - SourceSerifPro-ExtraLight.ttf
-    - SourceSerifPro-ExtraLightIt.ttf
-    - SourceSerifPro-It.ttf
-    - SourceSerifPro-Light.ttf
-    - SourceSerifPro-LightIt.ttf
-    - SourceSerifPro-Regular.ttf
-    - SourceSerifPro-Semibold.ttf
-    - SourceSerifPro-SemiboldIt.ttf
+    - name: Source Code Pro
+      styles:
+        - type: Black
+          font: SourceCodePro-Black.ttf
+
+        - type: Black Italic
+          font: SourceCodePro-BlackIt.ttf
+
+        - type: Bold
+          font: SourceCodePro-Bold.ttf
+
+        - type: Bold Italic
+          font: SourceCodePro-BoldIt.ttf
+
+        - type: Extra Light
+          font: SourceCodePro-ExtraLight.ttf
+
+        - type: ExtraLightIt
+          font: SourceCodePro-ExtraLightIt.ttf
+
+        - type: Italic
+          font: SourceCodePro-It.ttf
+
+        - type: Light
+          font: SourceCodePro-Light.ttf
+
+        - type: Light Italic
+          font: SourceCodePro-LightIt.ttf
+
+        - type: Medium
+          font: SourceCodePro-Medium.ttf
+
+        - type: Medium Italic
+          font: SourceCodePro-MediumIt.ttf
+
+        - type: Regular
+          font: SourceCodePro-Regular.ttf
+
+        - type: Semibold
+          font: SourceCodePro-Semibold.ttf
+
+        - type: Semibold Italic
+          font: SourceCodePro-SemiboldIt.ttf
+
+    - name: Source Sans Pro
+      styles:
+        - type: Black
+          font: SourceSansPro-Black.ttf
+
+        - type: Black Italic
+          font: SourceSansPro-BlackIt.ttf
+
+        - type: Bold
+          font: SourceSansPro-Bold.ttf
+
+        - type: Bold Italic
+          font: SourceSansPro-BoldIt.ttf
+
+        - type: Extra Light
+          font: SourceSansPro-ExtraLight.ttf
+
+        - type: ExtraLightIt
+          font: SourceSansPro-ExtraLightIt.ttf
+
+        - type: Italic
+          font: SourceSansPro-It.ttf
+
+        - type: Light
+          font: SourceSansPro-Light.ttf
+
+        - type: Light Italic
+          font: SourceSansPro-LightIt.ttf
+
+        - type: Medium
+          font: SourceSansPro-Medium.ttf
+
+        - type: Medium Italic
+          font: SourceSansPro-MediumIt.ttf
+
+        - type: Regular
+          font: SourceSansPro-Regular.ttf
+
+        - type: Semibold
+          font: SourceSansPro-Semibold.ttf
+
+        - type: Semibold Italic
+          font: SourceSansPro-SemiboldIt.ttf
+
+    - name: Source Serif Pro
+      styles:
+        - type: Black
+          font: SourceSerifPro-Black.ttf
+
+        - type: Black Italic
+          font: SourceSerifPro-BlackIt.ttf
+
+        - type: Bold
+          font: SourceSerifPro-Bold.ttf
+
+        - type: Bold Italic
+          font: SourceSerifPro-BoldIt.ttf
+
+        - type: Extra Light
+          font: SourceSerifPro-ExtraLight.ttf
+
+        - type: ExtraLightIt
+          font: SourceSerifPro-ExtraLightIt.ttf
+
+        - type: Italic
+          font: SourceSerifPro-It.ttf
+
+        - type: Light
+          font: SourceSerifPro-Light.ttf
+
+        - type: Light Italic
+          font: SourceSerifPro-LightIt.ttf
+
+        - type: Medium
+          font: SourceSerifPro-Medium.ttf
+
+        - type: Medium Italic
+          font: SourceSerifPro-MediumIt.ttf
+
+        - type: Regular
+          font: SourceSerifPro-Regular.ttf
+
+        - type: Semibold
+          font: SourceSerifPro-Semibold.ttf
+
+        - type: Semibold Italic
+          font: SourceSerifPro-SemiboldIt.ttf
+
+    - name: Source Han Sans
+      styles:
+        - type: Regular
+          font: SourceHanSans-Regular.ttc
+
+        - type: Normal
+          font: SourceHanSans-Normal.ttc
+
+        - type: Bold
+          font: SourceHanSans-Bold.ttc
+
+        - type: ExtraLight
+          font: SourceHanSans-ExtraLight.ttc
+
+        - type: Heavy
+          font: SourceHanSans-Heavy.ttc
+
+        - type: Light
+          font: SourceHanSans-Light.ttc
+
+        - type: Medium
+          font: SourceHanSans-Medium.ttc
 
   file_size: "101440249"
   sha: "0107b5d4ba305cb4dff2ba19138407aa2153632a2c41592f74d20cd0d0261bfd"

--- a/lib/fontist/finder.rb
+++ b/lib/fontist/finder.rb
@@ -21,13 +21,11 @@ module Fontist
     end
 
     def remote_source
-      Fontist::Source.formulas.to_h.select do |key, value|
-        !value.fonts.grep(/#{name}/i).empty?
-      end
+      Fontist::FormulaFinder.find(name)
     end
 
     def downloadable_font
-      unless remote_source.empty?
+      unless remote_source.nil?
         raise(
           Fontist::Errors::MissingFontError,
           "Fonts are missing, please run" \

--- a/lib/fontist/formula_finder.rb
+++ b/lib/fontist/formula_finder.rb
@@ -1,0 +1,80 @@
+module Fontist
+  class FormulaFinder
+    def initialize(font_name)
+      @font_name = font_name
+    end
+
+    def self.find(font_name)
+      new(font_name).find
+    end
+
+    def find
+      formulas = find_formula
+      build_formulas_array(formulas)
+    end
+
+    private
+
+    attr_reader :font_name
+
+    def build_formulas_array(formulas)
+      unless formulas.empty?
+        Array.new.tap do |formula_array|
+          formulas.each do |key|
+            formula_array.push(
+              key: key.to_s,
+              installer: formula_installers[key]
+            )
+          end
+        end
+      end
+    end
+
+    def find_formula
+      find_by_font_name || find_by_font || []
+    end
+
+    def formulas
+      @formulas ||=  Fontist::Source.formulas.to_h
+    end
+
+    def formula_installers
+      {
+        msvista: Fontist::Formulas::MsVista,
+        ms_system: Fontist::Formulas::MsSystem,
+        courier: Fontist::Formulas::CourierFont,
+        source_front: Fontist::Formulas::SourceFont,
+      }
+    end
+
+    def find_by_font_name
+      formula_names = formulas.select do |key, value|
+        !value.fonts.map(&:name).grep(/#{font_name}/i).empty?
+      end.keys
+
+      formula_names.empty? ? nil : formula_names
+    end
+
+    # Note
+    #
+    # These interface recursively look into every single font styles,
+    # so ideally try to avoid using it when possible, and that's why
+    # we've added it as last option in formula finder.
+    #
+    def find_by_font
+      formula_names = formulas.select do |key, value|
+        match_in_font_styles?(value.fonts)
+      end.keys
+
+      formula_names.empty? ? nil : formula_names
+    end
+
+    def match_in_font_styles?(fonts)
+      styles = fonts.select do |font|
+        !font.styles.map(&:font).grep(/#{font_name}/i).empty?
+      end
+
+      styles.empty? ? false : true
+    end
+  end
+end

--- a/lib/fontist/installer.rb
+++ b/lib/fontist/installer.rb
@@ -20,29 +20,23 @@ module Fontist
 
     attr_reader :font_name, :confirmation, :options
 
-    def downloaders
-      {
-        msvista: Fontist::Formulas::MsVista,
-        ms_system: Fontist::Formulas::MsSystem,
-        source_front: Fontist::Formulas::SourceFont,
-      }
-    end
-
     def find_system_font
       Fontist::SystemFont.find(font_name)
     end
 
-    def download_font
-      if !font_sources.empty?
-        downloader = downloaders[font_sources.first]
-        downloader.fetch_font(font_name, confirmation: confirmation)
-      end
+    def font_formulas
+      Fontist::FormulaFinder.find(font_name)
     end
 
-    def font_sources
-      @font_sources ||= Fontist::Source.formulas.to_h.select do |key, value|
-        !value.fonts.grep(/#{font_name}/i).empty?
-      end.keys
+    def download_font
+      if font_formulas
+        font_formulas.map do |formula|
+          formula[:installer].fetch_font(
+            font_name,
+            confirmation: confirmation,
+          )
+        end.flatten
+      end
     end
   end
 end

--- a/spec/fontist/finder_spec.rb
+++ b/spec/fontist/finder_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Fontist::Finder do
 
     context "with downloadable ms vista font" do
       it "returns missing font error" do
-        name = "CALIBRI.TTF"
+        name = "Calibri"
         allow(Fontist::SystemFont).to receive(:find).and_return(nil)
 
         expect {

--- a/spec/fontist/formula_finder_spec.rb
+++ b/spec/fontist/formula_finder_spec.rb
@@ -1,0 +1,36 @@
+require "spec_helper"
+
+RSpec.describe Fontist::FormulaFinder do
+  describe ".find" do
+    context "by font name" do
+      it "returns the font formulas" do
+        name = "Calibri"
+        formulas = Fontist::FormulaFinder.find(name)
+
+        expect(formulas.count).to eq(1)
+        expect(formulas.first[:key]).to eq("msvista")
+        expect(formulas.first[:installer]).to eq(Fontist::Formulas::MsVista)
+      end
+    end
+
+    context "by exact font" do
+      it "returns the font formulas" do
+        name = "CAMBRIAI.TTF"
+        formulas = Fontist::FormulaFinder.find(name)
+
+        expect(formulas.count).to eq(1)
+        expect(formulas.first[:key]).to eq("msvista")
+        expect(formulas.first[:installer]).to eq(Fontist::Formulas::MsVista)
+      end
+    end
+
+    context "for invalid font" do
+      it "returns nil to the caller" do
+        name = "Calibri Made Up Name"
+        formulas = Fontist::FormulaFinder.find(name)
+
+        expect(formulas).to be_nil
+      end
+    end
+  end
+end

--- a/spec/fontist/installer_spec.rb
+++ b/spec/fontist/installer_spec.rb
@@ -3,8 +3,8 @@ require "spec_helper"
 RSpec.describe Fontist::Installer do
   describe ".download" do
     context "with already downloaded fonts", skip_in_windows: true do
-      it "returns the font path" do
-        name = "CALIBRI.TTF"
+      it "returns the font path", file_download: true do
+        name = "Arial"
         Fontist::Formulas::MsVista.fetch_font(name, confirmation: "yes")
 
         allow(Fontist::Formulas::MsVista).to receive(:fetch_font).and_return(nil)
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Installer do
 
     context "with missing but downloadable fonts" do
       it "downloads and install the fonts", skip_in_windows: true do
-        name = "CALIBRI.TTF"
+        name = "Arial"
         confirmation = "yes"
         allow(Fontist::SystemFont).to receive(:find).and_return(nil)
 
@@ -26,7 +26,7 @@ RSpec.describe Fontist::Installer do
       end
 
       it "do not download if user didn't agree" do
-        name = "CALIBRI.TTF"
+        name = "Calibri"
         allow(Fontist::SystemFont).to receive(:find).and_return(nil)
 
         expect {

--- a/spec/fontist/source_spec.rb
+++ b/spec/fontist/source_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Fontist::Source do
 
       expect(formulas.msvista.license).not_to be_nil
       expect(formulas.msvista.file_size).to eq("62914560")
-      expect(formulas.msvista.fonts).to include("CALIBRI.TTF")
+      expect(formulas.msvista.fonts.map(&:name)).to include("Calibri")
     end
   end
 end


### PR DESCRIPTION
As of now, we are doing hard lookup for fonts by their exact name and also there are no way to specify font meta data like human readable name or different styles.

But in the long term plan - moving forward with font formulas we need to specify font style as well. So, this commit adds those necessary changes so we can specify font name, and the styles for font. This also adopt this changes for the lookup