### PR TITLE
Adopt font lookup for font meta data

### DIFF
--- a/lib/fontist/formula_finder.rb
+++ b/lib/fontist/formula_finder.rb
@@ -8,9 +8,23 @@ module Fontist
       new(font_name).find
     end
 
+    def self.find_fonts(name)
+      new(name).find_fonts
+    end
+
     def find
       formulas = find_formula
       build_formulas_array(formulas)
+    end
+
+    def find_fonts
+      matched_fonts = find_formula.map do |key, _value|
+        formulas[key].fonts.select do |font|
+          font.name == font_name
+        end
+      end
+
+      matched_fonts.empty? ? nil : matched_fonts.flatten
     end
 
     private

--- a/lib/fontist/formulas/base.rb
+++ b/lib/fontist/formulas/base.rb
@@ -20,9 +20,9 @@ module Fontist
       end
 
       def fetch
-        extract_fonts([font_name])
-        matched_fonts_uniq = matched_fonts.flatten.uniq
+        extract_fonts(map_names_to_fonts(font_name))
 
+        matched_fonts_uniq = matched_fonts.flatten.uniq
         matched_fonts_uniq.empty? ? nil : matched_fonts_uniq
       end
 
@@ -53,6 +53,13 @@ module Fontist
         @matched_fonts.push(font) if font
 
         font
+      end
+
+      def map_names_to_fonts(font_name)
+        fonts = FormulaFinder.find_fonts(font_name)
+        fonts = fonts.map { |font| font.styles.map(&:font) }.flatten if fonts
+
+        fonts || []
       end
 
       def download_file(source)

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -13,6 +13,8 @@ module Fontist
 
     def find
       paths = font_paths.grep(/#{font}/i)
+      paths = lookup_using_font_name || []  if paths.empty?
+
       paths.empty? ? nil : paths
     end
 
@@ -33,6 +35,11 @@ module Fontist
         default_sources["paths"] +
         [fontist_fonts_path.join("**")]
       ).flatten.uniq)
+    end
+
+    def lookup_using_font_name
+      font_names = map_name_to_valid_font_names
+      font_paths.grep(/#{font_names.join("|")}/i) if font_names
     end
 
     def fontist_fonts_path
@@ -61,5 +68,9 @@ module Fontist
       )
     end
 
+    def map_name_to_valid_font_names
+      fonts =  FormulaFinder.find_fonts(font)
+      fonts.map { |font| font.styles.map(&:font) }.flatten if fonts
+    end
   end
 end

--- a/spec/fontist/formula_finder_spec.rb
+++ b/spec/fontist/formula_finder_spec.rb
@@ -33,4 +33,22 @@ RSpec.describe Fontist::FormulaFinder do
       end
     end
   end
+
+  describe ".find_fonts" do
+    it "returns the exact font font names" do
+      name = "Calibri"
+      font = Fontist::FormulaFinder.find_fonts(name).first
+
+      expect(font.styles.map(&:font)).to include("CALIBRI.TTF")
+      expect(font.styles.map(&:font)).to include("CALIBRIB.TTF")
+      expect(font.styles.map(&:font)).to include("CALIBRII.TTF")
+    end
+
+    it "returns nil if invalid name provided" do
+      name = "Calibri Invlaid"
+      fonts = Fontist::FormulaFinder.find_fonts(name)
+
+      expect(fonts).to be_nil
+    end
+  end
 end

--- a/spec/fontist/formulas/courier_font_spec.rb
+++ b/spec/fontist/formulas/courier_font_spec.rb
@@ -3,15 +3,15 @@ require "spec_helper"
 RSpec.describe Fontist::Formulas::CourierFont do
   describe ".fetch_font" do
     context "with valid licence", skip_in_windows: true do
-      it "downloads and returns the fonts", file_download: true do
-        name = "cour"
+      it "downloads and returns the fonts" do
+        name = "Courier"
         stub_fontist_path_to_assets
         fonts = Fontist::Formulas::CourierFont.fetch_font(
           name, confirmation: "yes", force_download: true
         )
 
         expect(fonts.count).to eq(4)
-        expect(fonts.first).to include(name)
+        expect(fonts.first).to include("fonts/cour.ttf")
         expect(Fontist::Finder.find(name)).not_to be_empty
       end
     end

--- a/spec/fontist/system_font_spec.rb
+++ b/spec/fontist/system_font_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe Fontist::SystemFont do
       end
     end
 
+    context "with valid font name" do
+      it "returns the complete font path", file_download: true do
+        name = "Courier"
+        stub_fontist_path_to_assets
+        Fontist::Formulas::CourierFont.fetch_font(name, confirmation: "yes")
+
+        courier = Fontist::SystemFont.find(name, sources: [font_sources])
+        expect(courier.first).to include("cour.ttf")
+      end
+    end
+
     context "with invalid font" do
       it "returns nill to the caller" do
         name = "invalid-font.ttf"


### PR DESCRIPTION
Previously, we were only using the direct font name for lookup and installation, so it was pretty straight forward. But, now that font lookup/installation using font meta data like, name so this commit adopt those changes.

This changes the system font interface and as well as the base formula interface, so the library should work as expected.