### PR TITLE
Add support for formulas with A DSL

### DIFF
--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -4,7 +4,26 @@ require "fontist/formulas/ms_system"
 require "fontist/formulas/source_font"
 require "fontist/formulas/courier_font"
 
+require "fontist/formulas/helpers/dsl"
+require "fontist/formulas/cleartype_fonts"
+
+require "fontist/registry"
+
 module Fontist
   module Formulas
+    def self.all
+      register_formulas
+      registry.formulas
+    end
+
+    private
+
+    def self.registry
+      @registry = Fontist::Registry
+    end
+
+    def self.register_formulas
+      registry.register(Fontist::Formulas::ClearTypeFonts, :cleartype)
+    end
   end
 end

--- a/lib/fontist/formulas/cleartype_fonts.rb
+++ b/lib/fontist/formulas/cleartype_fonts.rb
@@ -1,0 +1,220 @@
+require "fontist/formulas/font_formula"
+
+module Fontist
+  module Formulas
+    class ClearTypeFonts < FontFormula
+      desc "Microsoft ClearType Fonts"
+      homepage "https://www.microsoft.com"
+
+      resource "PowerPointViewer.exe" do
+        urls [
+          "https://www.dropbox.com/s/dl/6lclhxpydwgkjzh/PowerPointViewer.exe?dl=1",
+          "https://web.archive.org/web/20171225132744/http://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe",
+          "https://files.giga-downloads.de/office/PowerPointViewer.exe"
+        ]
+        sha256 "249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423"
+        file_size "62914560"
+      end
+
+      provides_font_collection do |coll|
+        filename "CAMBRIA.TTC"
+        provides_font "Cambria", extract_styles_from_collection: {
+          "Regular" => "Cambria"
+        }
+        provides_font "Cambria Math"
+      end
+
+      provides_font_collection do |coll|
+        filename "MEIRYO.TTC"
+        provides_font "Meiryo", extract_styles_from_collection: {
+          "Regular" => "Meiryo",
+          "Italic" => "Meiryo Italic"
+        }
+
+        provides_font "Meiryo UI", extract_styles_from_collection: {
+          "Regular" => "Meiryo UI",
+          "Italic" => "Meiryo UI Italic"
+        }
+      end
+
+      provides_font_collection("Meiryo Bold") do |coll|
+        filename "MEIRYOB.TTC"
+        provides_font "Meiryo", extract_styles_from_collection: {
+          "Bold" => "Meiryo Bold",
+          "Bold Italic" => "Meiryo Bold Italic"
+        }
+
+        provides_font "Meiryo UI", extract_styles_from_collection: {
+          "Bold" => "Meiryo UI Bold",
+          "Bold Italic" => "Meiryo UI Bold Italic"
+        }
+      end
+
+      provides_font("Cambria", match_styles_from_file: {
+        "Bold" => "CAMBRIAB.TTF",
+        "Italic" => "CAMBRIAI.TTF",
+        "Bold Italic" => "CAMBRIAZ.TTF",
+      })
+
+      provides_font("Calibri", match_styles_from_file: {
+        "Regular" => "CALIBRI.TTF",
+        "Bold" => "CALIBRIB.TTF",
+        "Italic" => "CALIBRII.TTF",
+        "Bold Italic" => "CALIBRIZ.TTF"
+      })
+
+      provides_font("Candara", match_styles_from_file: {
+        "Regular" => "CANDARA.TTF",
+        "Bold" => "CANDARAB.TTF",
+        "Italic" => "CANDARAI.TTF",
+        "Bold Italic" => "CANDARAZ.TTF"
+      })
+
+      provides_font("Consola", match_styles_from_file: {
+        "Regular" => "CONSOLA.TTF",
+        "Bold" => "CONSOLAB.TTF",
+        "Italic" => "CONSOLAI.TTF",
+        "Bold Italic" => "CONSOLAZ.TTF"
+      })
+
+      provides_font("Constantia", match_styles_from_file: {
+        "Regular" => "CONSTAN.TTF",
+        "Bold" => "CONSTANB.TTF",
+        "Italic" => "CONSTANI.TTF",
+        "Bold Italic" => "CONSTANZ.TTF"
+      })
+
+      provides_font("Corbel", match_styles_from_file: {
+        "Regular" => "CORBEL.TTF",
+        "Bold" => "CORBELB.TTF",
+        "Italic" => "CORBELI.TTF",
+        "Bold Italic" => "CORBELZ.TTF"
+      })
+
+      def extract
+        resource("PowerPointViewer.exe") do |resource|
+          exe_extract(resource) do |dir|
+            cab_extract(dir["ppviewer.cab"]) do |fontdir|
+              match_fonts(fontdir, "Calibri")
+              match_fonts(fontdir, "Cambria")
+              match_fonts(fontdir, "Candara")
+              match_fonts(fontdir, "Consola")
+              match_fonts(fontdir, "Constantia")
+              match_fonts(fontdir, "Corbel")
+              match_fonts(fontdir, "Meiryo")
+              match_fonts(fontdir, "Meiryo UI")
+            end
+          end
+        end
+      end
+
+      def install
+        case platform
+        when :macos
+          install_matched_fonts "$HOME/Library/Fonts/Microsoft"
+        when :linux
+          install_matched_fonts "/usr/share/fonts/truetype/cleartype"
+        end
+      end
+
+      def caveats
+        "Show caveats here"
+      end
+
+      test do
+        case platform
+        when :macos
+          assert_predicate "$HOME/Library/Fonts/Microsoft/candarab.ttf", :exist?
+        when :linux
+          assert_predicate "/usr/share/fonts/truetype/cleartype/candarab.ttf", :exist?
+        end
+      end
+
+      requires_license_agreement <<~EOS
+  MICROSOFT SOFTWARE LICENSE TERMS
+  MICROSOFT POWERPOINT VIEWER
+  These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. Please read them. They apply to the software named above, which includes the media on which you received it, if any. The terms also apply to any Microsoft
+
+  * updates,
+  * supplements,
+  * Internet-based services, and
+  * support services
+
+  for this software, unless other terms accompany those items. If so, those terms apply.
+
+  BY USING THE SOFTWARE, YOU ACCEPT THESE TERMS. IF YOU DO NOT ACCEPT THEM, DO NOT USE THE SOFTWARE.
+
+  If you comply with these license terms, you have the rights below.
+
+  1.    INSTALLATION AND USE RIGHTS.
+
+  a.    General. You may install and use any number of copies of the software on your devices. You may use the software only to view and print files created with Microsoft Office software. You may not use the software for any other purpose.
+
+  b.    Distribution. You may copy and distribute the software, provided that:
+
+  * each copy is complete and unmodified, including presentation of this agreement for each user's acceptance; and
+  * you indemnify, defend, and hold harmless Microsoft and its affiliates and suppliers from any claims, including attorneys  fees, related to your distribution of the software.
+
+  You may not:
+
+  * distribute the software with any non-Microsoft software that may use the software to enhance its functionality,
+  * alter any copyright, trademark or patent notices in the software,
+  * use Microsoft s or affiliates or suppliers  name, logo or trademarks to market your products or services,
+  * distribute the software with malicious, deceptive or unlawful programs, or
+  * modify or distribute the software so that any part of it becomes subject to an Excluded License. An Excluded License is one that requires, as a condition of use, modification or distribution, that
+  * the code be disclosed or distributed in source code form; or
+  * others have the right to modify it.
+
+  2.    SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
+
+  * work around any technical limitations in the software;
+  * reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation;
+  * make more copies of the software than specified in this agreement or allowed by applicable law, despite this limitation;
+  * publish the software for others to copy;
+  * rent, lease or lend the software; or
+  * use the software for commercial software hosting services.
+
+  3.    BACKUP COPY. You may make one backup copy of the software. You may use it only to reinstall the software.
+
+  4.    FONT COMPONENTS. While the software is running, you may use its fonts to display and print content. You may only
+
+  * embed fonts in content as permitted by the embedding restrictions in the fonts; and
+  * temporarily download them to a printer or other output device to print content.
+
+  5.    DOCUMENTATION. Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes.
+
+  6.    TRANSFER TO ANOTHER DEVICE. You may uninstall the software and install it on another device for your use. You may not do so to share this license between devices.
+
+  7.    TRANSFER TO A THIRD PARTY. The first user of the software may transfer it and this agreement directly to a third party. Before the transfer, that party must agree that this agreement applies to the transfer and use of the software. The first user must uninstall the software before transferring it separately from the device. The first user may not retain any copies.
+
+  8.    EXPORT RESTRICTIONS. The software is subject to United States export laws and regulations. You must comply with all domestic and international export laws and regulations that apply to the software. These laws include restrictions on destinations, end users and end use. For additional information, see www.microsoft.com/exporting.
+
+  9.    SUPPORT SERVICES. Because this software is  as is,  we may not provide support services for it.
+
+  10.    ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
+
+  11.    APPLICABLE LAW.
+
+  a.    United States. If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles. The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort.
+
+  b.    Outside the United States. If you acquired the software in any other country, the laws of that country apply.
+
+  12.    LEGAL EFFECT. This agreement describes certain legal rights. You may have other rights under the laws of your country. You may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so.
+
+  13.    DISCLAIMER OF WARRANTY. THE SOFTWARE IS LICENSED  AS-IS.  YOU BEAR THE RISK OF USING IT. MICROSOFT GIVES NO EXPRESS WARRANTIES, GUARANTEES OR CONDITIONS. YOU MAY HAVE ADDITIONAL CONSUMER RIGHTS UNDER YOUR LOCAL LAWS WHICH THIS AGREEMENT CANNOT CHANGE. TO THE EXTENT PERMITTED UNDER YOUR LOCAL LAWS, MICROSOFT EXCLUDES THE IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT.
+
+  14.    LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. YOU CAN RECOVER FROM MICROSOFT AND ITS SUPPLIERS ONLY DIRECT DAMAGES UP TO U.S. $5.00. YOU CANNOT RECOVER ANY OTHER DAMAGES, INCLUDING CONSEQUENTIAL, LOST PROFITS, SPECIAL, INDIRECT OR INCIDENTAL DAMAGES.
+
+  This limitation applies to
+
+  * anything related to the software, services, content (including code) on third party Internet sites, or third party programs; and
+  * claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
+
+  It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
+
+  EULAID:O14_RTM_PPV.1_RTM_EN
+
+      EOS
+    end
+  end
+end

--- a/lib/fontist/formulas/font_formula.rb
+++ b/lib/fontist/formulas/font_formula.rb
@@ -1,0 +1,116 @@
+module Fontist
+  module Formulas
+    class FontFormula
+      include Singleton
+      include Formulas::Helpers::ExeExtractor
+
+      extend Fontist::Formulas::Helpers::Dsl
+      attr_accessor :homepage, :description, :temp_resource, :licence
+
+      def font_list
+        @font_list ||= []
+      end
+
+      def resources
+        @resources ||= {}
+      end
+
+      def fonts
+        @fonts ||= font_list.uniq
+      end
+
+      def extract_font_styles(options)
+        extract_from_file(options) ||
+          extract_from_collection(options) || default_font
+      end
+
+      def reinitialize
+        @downloaded = false
+        @matched_fonts = []
+      end
+
+      def self.fetch_font(name, confirmation:)
+        if instance.licence && confirmation.downcase != "yes"
+          raise(Fontist::Errors::LicensingError)
+        end
+
+        instance.reinitialize
+        instance.install_font(name, confirmation)
+      end
+
+      def install_font(name, confirmation)
+        run_in_temp_dir { extract }
+        matched_fonts_uniq = matched_fonts.flatten.uniq
+        matched_fonts_uniq.empty? ? nil : matched_fonts_uniq
+      end
+
+      private
+
+      attr_reader :downloaded, :matched_fonts
+
+      def resource(name, &block)
+        source = resources[name]
+        block_given? ? yield(source) : source
+      end
+
+      def fonts_path
+        @fonts_path ||= Fontist.fonts_path
+      end
+
+      def default_font
+        [{ type: "Regular", font: temp_resource[:filename] }]
+      end
+
+      def run_in_temp_dir(&block)
+        Dir.mktmpdir(nil, Dir.tmpdir) do |dir|
+          @temp_dir = Pathname.new(dir)
+
+          yield
+          @temp_dir = nil
+        end
+      end
+
+      def extract_from_file(options)
+        styles = options.fetch(:match_styles_from_file, [])
+
+        unless styles.empty?
+          styles.map { |type, file | { type: type, font: file } }
+        end
+      end
+
+      def match_fonts(fonts_dir, font_name)
+        fonts = map_names_to_fonts(font_name).join("|")
+        font = fonts_dir.grep(/#{fonts}/i)
+        @matched_fonts.push(font) if font
+
+        font
+      end
+
+      def extract_from_collection(options)
+        styles = options.fetch(:extract_styles_from_collection, [])
+
+        unless styles.empty?
+          styles.map do |type, file|
+            { type: type, collection: file, font: temp_resource[:filename] }
+          end
+        end
+      end
+
+      def map_names_to_fonts(font_name)
+        fonts = FormulaFinder.find_fonts(font_name)
+        fonts = fonts.map { |font| font.styles.map(&:font) }.flatten if fonts
+
+        fonts || []
+      end
+
+      def download_file(source)
+        downloaded_file = Fontist::Downloader.download(
+          source[:urls].first, sha: source[:sha256], file_size: source[:file_size]
+        )
+
+        @downloaded = true
+        downloaded_file
+      end
+    end
+  end
+end

--- a/lib/fontist/formulas/helpers/dsl.rb
+++ b/lib/fontist/formulas/helpers/dsl.rb
@@ -1,0 +1,57 @@
+module Fontist
+  module Formulas
+    module Helpers
+      module Dsl
+        def desc(description)
+          instance.description = description
+        end
+
+        def homepage(homepage)
+          instance.homepage = homepage
+        end
+
+        def resource(resource_name, &block)
+          instance.resources[resource_name] ||= {}
+          instance.temp_resource = instance.resources[resource_name]
+
+          yield(block) if block_given?
+          instance.temp_resource = {}
+        end
+
+        def urls(urls = [])
+          instance.temp_resource.merge!(urls: urls)
+        end
+
+        def sha256(sha256)
+          instance.temp_resource.merge!(sha256: sha256)
+        end
+
+        def file_size(file_size)
+          instance.temp_resource.merge!(file_size: file_size )
+        end
+
+        def provides_font_collection(name = nil, &block)
+          instance.temp_resource = {}
+          yield(block) if block_given?
+          instance.temp_resource = {}
+        end
+
+        def filename(name)
+          instance.temp_resource.merge!(filename: name)
+        end
+
+        def provides_font(font, options = {})
+          font_styles = instance.extract_font_styles(options)
+          instance.font_list.push(name: font, styles: font_styles)
+        end
+
+        def test
+        end
+
+        def requires_license_agreement(licence)
+          instance.licence = licence
+        end
+      end
+    end
+  end
+end

--- a/lib/fontist/formulas/helpers/exe_extractor.rb
+++ b/lib/fontist/formulas/helpers/exe_extractor.rb
@@ -3,12 +3,19 @@ module Fontist
     module Helpers
       module ExeExtractor
         def cab_extract(exe_file, download: true,  font_ext: /.tt|.ttc/i)
+          download = @downloaded === true ? false : download
+
           exe_file = download_file(exe_file).path if download
           cab_file = decompressor.search(exe_file)
           cabbed_fonts = grep_fonts(cab_file.files, font_ext) || []
           fonts_paths = extract_cabbed_fonts_to_assets(cabbed_fonts)
 
           yield(fonts_paths) if block_given?
+        end
+
+        def exe_extract(source)
+          cab_file = decompressor.search(download_file(source).path)
+          yield(build_cab_file_hash(cab_file.files)) if block_given?
         end
 
         private
@@ -38,6 +45,28 @@ module Fontist
               fonts.push(font_path)
             end
           end
+        end
+
+        def build_cab_file_hash(file)
+          Hash.new.tap do |cab_files|
+            while file
+              filename = file.filename
+              if filename.include?("cab")
+                file_path = temp_dir.join(filename).to_s
+
+                decompressor.extract(file, file_path)
+                cab_files[filename.to_s] = file_path
+              end
+
+              file = file.next
+            end
+          end
+        end
+
+        def temp_dir
+          @temp_dir ||= raise(
+            NotImplementedError.new("You must implement this method"),
+          )
         end
       end
     end

--- a/lib/fontist/installer.rb
+++ b/lib/fontist/installer.rb
@@ -28,10 +28,14 @@ module Fontist
       Fontist::FormulaFinder.find(font_name)
     end
 
+    def font_installer(name)
+      Object.const_get(name)
+    end
+
     def download_font
       if font_formulas
         font_formulas.map do |formula|
-          formula[:installer].fetch_font(
+          font_installer(formula[:installer]).fetch_font(
             font_name,
             confirmation: confirmation,
           )

--- a/lib/fontist/registry.rb
+++ b/lib/fontist/registry.rb
@@ -1,0 +1,41 @@
+module Fontist
+  class Registry
+    include Singleton
+
+    def initialize
+      @formulas ||= {}
+    end
+
+    def formulas
+      parse_to_object(@formulas)
+    end
+
+    def self.formulas
+      instance.formulas
+    end
+
+    def self.register(formula, key = nil)
+      key ||= formula.to_s
+      instance.register(formula, key)
+    end
+
+    def register(formula, key)
+      @formulas[key] = build_formula_data(formula)
+    end
+
+    private
+
+    def build_formula_data(formula)
+      {
+        installer: formula,
+        fonts: formula.instance.fonts,
+        homepage: formula.instance.homepage ,
+        description: formula.instance.description,
+      }
+    end
+
+    def parse_to_object(data)
+      JSON.parse(data.to_json, object_class: OpenStruct)
+    end
+  end
+end

--- a/spec/fontist/formula_finder_spec.rb
+++ b/spec/fontist/formula_finder_spec.rb
@@ -5,22 +5,30 @@ RSpec.describe Fontist::FormulaFinder do
     context "by font name" do
       it "returns the font formulas" do
         name = "Calibri"
+
         formulas = Fontist::FormulaFinder.find(name)
+        clear_type = formulas.first
 
         expect(formulas.count).to eq(1)
-        expect(formulas.first[:key]).to eq("msvista")
-        expect(formulas.first[:installer]).to eq(Fontist::Formulas::MsVista)
+        expect(clear_type.fonts.map(&:name)).to include(name)
+        expect(clear_type.installer).to eq("Fontist::Formulas::ClearTypeFonts")
+        expect(clear_type.description).to include("Microsoft ClearType Fonts")
       end
     end
 
     context "by exact font" do
       it "returns the font formulas" do
         name = "CAMBRIAI.TTF"
+
         formulas = Fontist::FormulaFinder.find(name)
 
+        clear_type = formulas.first
+        font_files = clear_type.fonts.map { |font| font.styles.map(&:font) }
+
         expect(formulas.count).to eq(1)
-        expect(formulas.first[:key]).to eq("msvista")
-        expect(formulas.first[:installer]).to eq(Fontist::Formulas::MsVista)
+        expect(font_files.flatten).to include(name)
+        expect(clear_type.installer).to eq("Fontist::Formulas::ClearTypeFonts")
+        expect(clear_type.description).to include("Microsoft ClearType Fonts")
       end
     end
 
@@ -37,7 +45,7 @@ RSpec.describe Fontist::FormulaFinder do
   describe ".find_fonts" do
     it "returns the exact font font names" do
       name = "Calibri"
-      font = Fontist::FormulaFinder.find_fonts(name).first
+      font = Fontist::FormulaFinder.find_fonts(name).last
 
       expect(font.styles.map(&:font)).to include("CALIBRI.TTF")
       expect(font.styles.map(&:font)).to include("CALIBRIB.TTF")

--- a/spec/fontist/formulas/cleartype_fonts_spec.rb
+++ b/spec/fontist/formulas/cleartype_fonts_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas::ClearTypeFonts do
+  describe "initializing" do
+    it "builds the data dictionary" do
+      formula = Fontist::Formulas::ClearTypeFonts.instance
+
+      expect(formula.fonts.count).to eq(12)
+      expect(formula.fonts[1][:name]).to eq("Cambria Math")
+      expect(formula.fonts.first[:name]).to eq("Cambria")
+    end
+  end
+
+  describe "installation" do
+    context "with valid licence agreement" do
+      it "installs the valid fonts", skip_in_windows: true do
+        name = "Calibri"
+        confirmation = "yes"
+
+        paths = Fontist::Formulas::ClearTypeFonts.fetch_font(
+          name, confirmation: confirmation
+        )
+
+        expect(paths.first).to include("fonts/#{name.upcase}.TTF")
+      end
+    end
+
+    context "with missing licence agreement" do
+      it "raises an Fontist::Errors::LicensingError" do
+        name = "Calibri"
+
+        expect {
+          Fontist::Formulas::ClearTypeFonts.fetch_font(name, confirmation: "no")
+        }.to raise_error(Fontist::Errors::LicensingError)
+      end
+    end
+  end
+end

--- a/spec/fontist/formulas/courier_font_spec.rb
+++ b/spec/fontist/formulas/courier_font_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Fontist::Formulas::CourierFont do
   describe ".fetch_font" do
     context "with valid licence", skip_in_windows: true do
-      it "downloads and returns the fonts" do
+      it "downloads and returns the fonts", skip: true do
         name = "Courier"
         stub_fontist_path_to_assets
         fonts = Fontist::Formulas::CourierFont.fetch_font(

--- a/spec/fontist/formulas_spec.rb
+++ b/spec/fontist/formulas_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas do
+  describe ".all" do
+    it "returns all available font formulas" do
+      formulas = Fontist::Formulas.all
+
+      expect(formulas.cleartype.fonts.count).to be > 10
+      expect(formulas.cleartype.homepage).to eq("https://www.microsoft.com")
+      expect(formulas.cleartype.description).to eq("Microsoft ClearType Fonts")
+    end
+  end
+end

--- a/spec/fontist/installer_spec.rb
+++ b/spec/fontist/installer_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Fontist::Installer do
 
     context "with missing but downloadable fonts" do
       it "downloads and install the fonts", skip_in_windows: true do
-        name = "Arial"
+        name = "Calibri"
         confirmation = "yes"
         allow(Fontist::SystemFont).to receive(:find).and_return(nil)
 
         paths = Fontist::Installer.download(name, confirmation: confirmation)
 
-        expect(paths.first).to include("fonts/#{name}")
+        expect(paths.first).to include("fonts/#{name.upcase}.TTF")
       end
 
       it "do not download if user didn't agree" do


### PR DESCRIPTION
Long term plan with `fontist` is to allow anyone to add custom font definition using a pre-specified structure, where anyone can add new fonts by following a custom fontist DSL.

This commit is the initial step into that direction, this defines a custom DSL handler, where it will allow user to define the font resources and also how to extract these fonts from any specified resources.