### PR TITLE
Add the OpenSans font formula

### DIFF
--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -1,6 +1,6 @@
-
 require "down"
 require "digest"
+require "singleton"
 
 require "fontist/errors"
 require "fontist/version"
@@ -9,15 +9,11 @@ require "fontist/finder"
 require "fontist/source"
 require "fontist/installer"
 require "fontist/downloader"
-require "fontist/system_font"
 
+require "fontist/registry"
 require "fontist/formulas"
 require "fontist/formula_finder"
-
-require "singleton"
-require "fontist/registry"
-require "fontist/formulas/helpers/dsl"
-require "fontist/formulas/cleartype_fonts"
+require "fontist/system_font"
 
 module Fontist
   def self.lib_path

--- a/lib/fontist/downloader.rb
+++ b/lib/fontist/downloader.rb
@@ -9,15 +9,12 @@ module Fontist
 
     def download
       file = download_file
-      verify_file_checksum(file) || raise_invalid_file
-    end
 
-    def verify_file_checksum(file)
-      file if Digest::SHA256.file(file) === sha
-    end
+      if sha && Digest::SHA256.file(file) != sha
+        raise(Fontist::Errors::TemparedFileError)
+      end
 
-    def raise_invalid_file
-      raise(Fontist::Errors::TemparedFileError)
+      file
     end
 
     def self.download(file, options = {})

--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -1,3 +1,7 @@
+require "fontist/formulas/helpers/dsl"
+require "fontist/formulas/cleartype_fonts"
+require "fontist/formulas/open_sans_fonts"
+
 module Fontist
   module Formulas
     def self.all

--- a/lib/fontist/formulas/font_formula.rb
+++ b/lib/fontist/formulas/font_formula.rb
@@ -1,13 +1,16 @@
 require "fontist/formulas/helpers/exe_extractor"
+require "fontist/formulas/helpers/zip_extractor"
 
 module Fontist
   module Formulas
     class FontFormula
       include Singleton
       extend Fontist::Formulas::Helpers::Dsl
-
       include Fontist::Formulas::Helpers::ExeExtractor
-      attr_accessor :homepage, :description, :temp_resource, :licence
+      include Fontist::Formulas::Helpers::ZipExtractor
+
+      attr_accessor :license, :license_required
+      attr_accessor :homepage, :description, :temp_resource
 
       def font_list
         @font_list ||= []
@@ -32,7 +35,7 @@ module Fontist
       end
 
       def self.fetch_font(name, confirmation:)
-        if instance.licence && confirmation.downcase != "yes"
+        if instance.license_required && confirmation.downcase != "yes"
           raise(Fontist::Errors::LicensingError)
         end
 

--- a/lib/fontist/formulas/helpers/dsl.rb
+++ b/lib/fontist/formulas/helpers/dsl.rb
@@ -18,6 +18,10 @@ module Fontist
           instance.temp_resource = {}
         end
 
+        def url(url)
+          instance.temp_resource.merge!(urls: [url])
+        end
+
         def urls(urls = [])
           instance.temp_resource.merge!(urls: urls)
         end
@@ -48,8 +52,14 @@ module Fontist
         def test
         end
 
-        def requires_license_agreement(licence)
-          instance.licence = licence
+        def requires_license_agreement(license)
+          instance.license = license
+          instance.license_required = true
+        end
+
+        def open_license(license)
+          instance.license = license
+          instance.license_required = false
         end
       end
     end

--- a/lib/fontist/formulas/helpers/zip_extractor.rb
+++ b/lib/fontist/formulas/helpers/zip_extractor.rb
@@ -1,8 +1,10 @@
+require "zip"
+
 module Fontist
   module Formulas
     module Helpers
       module ZipExtractor
-        def zip_extract(resource, download: true, fonts_sub_dir: "/")
+        def zip_extract(resource, download: true, fonts_sub_dir: "")
           zip_file = download_file(resource) if download
           zip_file ||= resource.urls.first
 
@@ -12,7 +14,7 @@ module Fontist
 
         private
 
-        def unzip_fonts(file, fonts_sub_dir = "/")
+        def unzip_fonts(file, fonts_sub_dir = "")
           Zip.on_exists_proc = true
 
           Array.new.tap do |fonts|

--- a/lib/fontist/formulas/open_sans_fonts.rb
+++ b/lib/fontist/formulas/open_sans_fonts.rb
@@ -1,0 +1,263 @@
+module Fontist
+  module Formulas
+    class OpenSansFonts < FontFormula
+      desc "Open Sans Font"
+      homepage "https://www.ascender.com"
+
+      resource "open-sans.zip" do
+        url "https://www.fontsquirrel.com/fonts/download/open-sans"
+
+        # Note
+        #
+        # Fontsquirrel doesn't ensure each download will contains
+        # the same sha for the file, so we don't have a direct way
+        # to verify this unless we host a downloed file somewhere.
+        #
+        # sha256 "7a76476bd61eb3cb4fe19d08f528435db123f1a9167f8f0063f6f98cbf2662c4"
+      end
+
+      provides_font("OpenSans", match_styles_from_file: {
+        "Light" => "OpenSans-Light.ttf",
+        "Light Italic" => "OpenSans-LightItalic.ttf",
+        "Regular" => "OpenSans-Regular.ttf",
+        "Italic" => "OpenSans-Italic.ttf",
+        "Semibold" => "OpenSans-Semibold.ttf",
+        "Semibold Italic" => "OpenSans-SemiboldItalic.ttf",
+        "Bold" => "OpenSans-Bold.ttf",
+        "Bold Italic" => "OpenSans-BoldItalic.ttf",
+        "Extra Bold" => "OpenSans-ExtraBold.ttf",
+        "Extra Bold Italic" => "OpenSans-ExtraBoldItalic.ttf"
+      })
+
+      def extract
+        resource("open-sans.zip") do |resource|
+          zip_extract(resource) do |fontdir|
+            match_fonts(fontdir, "OpenSans")
+          end
+        end
+      end
+
+      def install
+        case platform
+        when :macos
+          install_matched_fonts "$HOME/Library/Fonts/OpenSans"
+        when :linux
+          install_matched_fonts "/usr/share/fonts/truetype/opensans"
+        end
+      end
+
+      test do
+        case platform
+        when :macos
+          assert_predicate "$HOME/Library/Fonts/OpenSans/OpenSans-LightItalic.ttf", :exist?
+        when :linux
+          assert_predicate "/usr/share/fonts/truetype/opensans/OpenSans-LightItalic.ttf", :exist?
+        end
+      end
+
+      open_license <<~EOS
+  Apache License
+                             Version 2.0, January 2004
+                          http://www.apache.org/licenses/
+
+     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+     1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction,
+        and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by
+        the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all
+        other entities that control, are controlled by, or are under common
+        control with that entity. For the purposes of this definition,
+        "control" means (i) the power, direct or indirect, to cause the
+        direction or management of such entity, whether by contract or
+        otherwise, or (ii) ownership of fifty percent (50%) or more of the
+        outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity
+        exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications,
+        including but not limited to software source code, documentation
+        source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical
+        transformation or translation of a Source form, including but
+        not limited to compiled object code, generated documentation,
+        and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or
+        Object form, made available under the License, as indicated by a
+        copyright notice that is included in or attached to the work
+        (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object
+        form, that is based on (or derived from) the Work and for which the
+        editorial revisions, annotations, elaborations, or other modifications
+        represent, as a whole, an original work of authorship. For the purposes
+        of this License, Derivative Works shall not include works that remain
+        separable from, or merely link (or bind by name) to the interfaces of,
+        the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including
+        the original version of the Work and any modifications or additions
+        to that Work or Derivative Works thereof, that is intentionally
+        submitted to Licensor for inclusion in the Work by the copyright owner
+        or by an individual or Legal Entity authorized to submit on behalf of
+        the copyright owner. For the purposes of this definition, "submitted"
+        means any form of electronic, verbal, or written communication sent
+        to the Licensor or its representatives, including but not limited to
+        communication on electronic mailing lists, source code control systems,
+        and issue tracking systems that are managed by, or on behalf of, the
+        Licensor for the purpose of discussing and improving the Work, but
+        excluding communication that is conspicuously marked or otherwise
+        designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity
+        on behalf of whom a Contribution has been received by Licensor and
+        subsequently incorporated within the Work.
+
+     2. Grant of Copyright License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        copyright license to reproduce, prepare Derivative Works of,
+        publicly display, publicly perform, sublicense, and distribute the
+        Work and such Derivative Works in Source or Object form.
+
+     3. Grant of Patent License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        (except as stated in this section) patent license to make, have made,
+        use, offer to sell, sell, import, and otherwise transfer the Work,
+        where such license applies only to those patent claims licensable
+        by such Contributor that are necessarily infringed by their
+        Contribution(s) alone or by combination of their Contribution(s)
+        with the Work to which such Contribution(s) was submitted. If You
+        institute patent litigation against any entity (including a
+        cross-claim or counterclaim in a lawsuit) alleging that the Work
+        or a Contribution incorporated within the Work constitutes direct
+        or contributory patent infringement, then any patent licenses
+        granted to You under this License for that Work shall terminate
+        as of the date such litigation is filed.
+
+     4. Redistribution. You may reproduce and distribute copies of the
+        Work or Derivative Works thereof in any medium, with or without
+        modifications, and in Source or Object form, provided that You
+        meet the following conditions:
+
+        (a) You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+
+        (b) You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+
+        (c) You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of
+            the Derivative Works; and
+
+        (d) If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+
+        You may add Your own copyright statement to Your modifications and
+        may provide additional or different license terms and conditions
+        for use, reproduction, or distribution of Your modifications, or
+        for any such Derivative Works as a whole, provided Your use,
+        reproduction, and distribution of the Work otherwise complies with
+        the conditions stated in this License.
+
+     5. Submission of Contributions. Unless You explicitly state otherwise,
+        any Contribution intentionally submitted for inclusion in the Work
+        by You to the Licensor shall be under the terms and conditions of
+        this License, without any additional terms or conditions.
+        Notwithstanding the above, nothing herein shall supersede or modify
+        the terms of any separate license agreement you may have executed
+        with Licensor regarding such Contributions.
+
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor,
+        except as required for reasonable and customary use in describing the
+        origin of the Work and reproducing the content of the NOTICE file.
+
+     7. Disclaimer of Warranty. Unless required by applicable law or
+        agreed to in writing, Licensor provides the Work (and each
+        Contributor provides its Contributions) on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied, including, without limitation, any warranties or conditions
+        of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+        PARTICULAR PURPOSE. You are solely responsible for determining the
+        appropriateness of using or redistributing the Work and assume any
+        risks associated with Your exercise of permissions under this License.
+
+     8. Limitation of Liability. In no event and under no legal theory,
+        whether in tort (including negligence), contract, or otherwise,
+        unless required by applicable law (such as deliberate and grossly
+        negligent acts) or agreed to in writing, shall any Contributor be
+        liable to You for damages, including any direct, indirect, special,
+        incidental, or consequential damages of any character arising as a
+        result of this License or out of the use or inability to use the
+        Work (including but not limited to damages for loss of goodwill,
+        work stoppage, computer failure or malfunction, or any and all
+        other commercial damages or losses), even if such Contributor
+        has been advised of the possibility of such damages.
+
+     9. Accepting Warranty or Additional Liability. While redistributing
+        the Work or Derivative Works thereof, You may choose to offer,
+        and charge a fee for, acceptance of support, warranty, indemnity,
+        or other liability obligations and/or rights consistent with this
+        License. However, in accepting such obligations, You may act only
+        on Your own behalf and on Your sole responsibility, not on behalf
+        of any other Contributor, and only if You agree to indemnify,
+        defend, and hold each Contributor harmless for any liability
+        incurred by, or claims asserted against, such Contributor by reason
+        of your accepting any such warranty or additional liability.
+
+     END OF TERMS AND CONDITIONS
+
+     APPENDIX: How to apply the Apache License to your work.
+
+        To apply the Apache License to your work, attach the following
+        boilerplate notice, with the fields enclosed by brackets "[]"
+        replaced with your own identifying information. (Don't include
+        the brackets!)  The text should be enclosed in the appropriate
+        comment syntax for the file format. We also recommend that a
+        file or class name and description of purpose be included on the
+        same "printed page" as the copyright notice for easier
+        identification within third-party archives.
+
+     Copyright [yyyy] [name of copyright owner]
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+      EOS
+    end
+  end
+end

--- a/spec/fontist/downloader_spec.rb
+++ b/spec/fontist/downloader_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+
 RSpec.describe Fontist::Downloader do
   describe ".download", file_download: true do
     it "return the valid downloaded file" do

--- a/spec/fontist/formulas/open_sans_fonts_spec.rb
+++ b/spec/fontist/formulas/open_sans_fonts_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas::OpenSansFonts do
+  describe "initializing" do
+    it "builds the data dictionary" do
+      formula = Fontist::Formulas::OpenSansFonts.instance
+
+      expect(formula.fonts.count).to eq(1)
+      expect(formula.fonts.first[:name]).to eq("OpenSans")
+    end
+  end
+
+  describe "installation" do
+    context "with valid licence agreement", file_download: true do
+      it "installs the valid fonts", skip_in_windows: true do
+        name = "OpenSans"
+        confirmation = "yes"
+
+        stub_fontist_path_to_assets
+        paths = Fontist::Formulas::OpenSansFonts.fetch_font(
+          name, confirmation: confirmation
+        )
+
+        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(paths.first).to include("fonts/#{name}-Light.ttf")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the OpenSans font formula, so now user should be able to use this with the fontist downloader. This will provide the following list of fonts.

```
OpenSans-Bold.ttf
OpenSans-BoldItalic.ttf
OpenSans-ExtraBold.ttf
OpenSans-ExtraBoldItalic.ttf
OpenSans-Italic.ttf
OpenSans-Light.ttf
OpenSans-LightItalic.ttf
OpenSans-Regular.ttf
OpenSans-Semibold.ttf
OpenSans-SemiboldItalic.ttf
```