### PR TITLE
Add font formula for montserrat fonts

### DIFF
--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -2,6 +2,7 @@ require "fontist/formulas/helpers/dsl"
 require "fontist/formulas/cleartype_fonts"
 require "fontist/formulas/open_sans_fonts"
 require "fontist/formulas/euphemia_font"
+require "fontist/formulas/montserrat_font"
 
 module Fontist
   module Formulas
@@ -20,6 +21,7 @@ module Fontist
       registry.register(Fontist::Formulas::ClearTypeFonts, :cleartype)
       registry.register(Fontist::Formulas::OpenSansFonts, :open_sans_fonts)
       registry.register(Fontist::Formulas::EuphemiaFont, :euphemia_font)
+      registry.register(Fontist::Formulas::MontserratFont, :montserrat_font)
     end
   end
 end

--- a/lib/fontist/formulas/helpers/zip_extractor.rb
+++ b/lib/fontist/formulas/helpers/zip_extractor.rb
@@ -19,7 +19,7 @@ module Fontist
 
           Array.new.tap do |fonts|
             Zip::File.open(file) do |zip_file|
-              zip_file.glob("#{fonts_sub_dir}*.{ttf,ttc}").each do |entry|
+              zip_file.glob("#{fonts_sub_dir}*.{ttf,ttc,otf}").each do |entry|
                 filename = entry.name.gsub("#{fonts_sub_dir}", "")
 
                 if filename

--- a/lib/fontist/formulas/montserrat_font.rb
+++ b/lib/fontist/formulas/montserrat_font.rb
@@ -1,0 +1,132 @@
+module Fontist
+  module Formulas
+    class MontserratFont < FontFormula
+      desc "Montserrat Font"
+      homepage "https://github.com/JulietaUla/Montserrat"
+
+      resource "montserrat.zip" do
+        url "https://www.fontsquirrel.com/fonts/download/montserrat"
+
+        # Same issue here
+        # sha256 "ea1d3721cba61e4de81f4425dee191c904e44129c07d825082d70ee4e168c437"
+      end
+
+      provides_font("Montserrat", match_styles_from_file: {
+        "Thin" => "Montserrat-Thin.otf",
+        "ThinItalic" => "Montserrat-ThinItalic.otf",
+        "ExtraLight" => "Montserrat-ExtraLight.otf",
+        "ExtraLight Italic" => "Montserrat-ExtraLightItalic.otf",
+        "Light" => "Montserrat-Light.otf",
+        "Light Italic" => "Montserrat-LightItalic.otf",
+        "Regular" => "Montserrat-Regular.otf",
+        "Italic" => "Montserrat-Italic.otf",
+        "Medium" => "Montserrat-Medium.otf",
+        "Medium Italic" => "Montserrat-MediumItalic.otf",
+        "SemiBold" => "Montserrat-SemiBold.otf",
+        "SemiBold Italic" => "Montserrat-SemiBoldItalic.otf",
+        "Bold" => "Montserrat-Bold.otf",
+        "Bold Italic" => "Montserrat-BoldItalic.otf",
+        "ExtraBold" => "Montserrat-ExtraBold.otf",
+        "ExtraBold Italic" => "Montserrat-ExtraBoldItalic.otf",
+        "Black" => "Montserrat-Black.otf",
+        "Black Italic" => "Montserrat-BlackItalic.otf"
+      })
+
+      provides_font("Montserrat Alternates", match_styles_from_file: {
+        "Thin" => "MontserratAlternates-Thin.otf",
+        "Thin Italic" => "MontserratAlternates-ThinItalic.otf",
+        "ExtraLight" => "MontserratAlternates-ExtraLight.otf",
+        "ExtraLight Italic" => "MontserratAlternates-ExtraLightItalic.otf",
+        "Light" => "MontserratAlternates-Light.otf",
+        "Light Italic" => "MontserratAlternates-LightItalic.otf",
+        "Regular" => "MontserratAlternates-Regular.otf",
+        "Italic" => "MontserratAlternates-Italic.otf",
+        "Medium" => "MontserratAlternates-Medium.otf",
+        "Medium Italic" => "MontserratAlternates-MediumItalic.otf",
+        "SemiBold" => "MontserratAlternates-SemiBold.otf",
+        "SemiBold Italic" => "MontserratAlternates-SemiBoldItalic.otf",
+        "Bold" => "MontserratAlternates-Bold.otf",
+        "Bold Italic" => "MontserratAlternates-BoldItalic.otf",
+        "ExtraBold" => "MontserratAlternates-ExtraBold.otf",
+        "ExtraBold Italic" => "MontserratAlternates-ExtraBoldItalic.otf",
+        "Black" => "MontserratAlternates-Black.otf",
+        "Black Italic" => "MontserratAlternates-BlackItalic.otf",
+      })
+
+      def extract
+        resource("montserrat.zip") do |resource|
+          zip_extract(resource) do |fontdir|
+            match_fonts(fontdir, "Montserrat")
+            match_fonts(fontdir, "Montserrat Alternates")
+          end
+        end
+      end
+
+      def install
+        case platform
+        when :macos
+          install_matched_fonts "$HOME/Library/Fonts/Montserrat"
+        when :linux
+          install_matched_fonts "/usr/share/fonts/truetype/montserrat"
+        end
+      end
+
+      test do
+        case platform
+        when :macos
+          assert_predicate "$HOME/Library/Fonts/Montserrat/MontserratAlternates-Thin.otf", :exist?
+        when :linux
+          assert_predicate "/usr/share/fonts/truetype/montserrat/MontserratAlternates-Thin.otf", :exist?
+        end
+      end
+
+      open_license <<~EOS
+  Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide development of collaborative font projects, to support the font creation efforts of academic and linguistic communities, and to provide a free and open framework in which fonts may be shared and improved in partnership with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and redistributed freely as long as they are not sold by themselves. The fonts, including any derivative works, can be bundled, embedded, redistributed and/or sold with any software provided that any reserved names are not used by derivative works. The fonts and derivatives, however, cannot be released under any other type of license. The requirement for fonts to remain under this license does not apply to any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright Holder(s) under this license and clearly marked as such. This may include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software components as distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to, deleting, or substituting -- in part or in whole -- any of the components of the Original Version, by changing formats or by porting the Font Software to a new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical writer or other person who contributed to the Font Software.
+
+  PERMISSION & CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining a copy of the Font Software, to use, study, copy, merge, embed, modify, redistribute, and sell modified and unmodified copies of the Font Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components, in Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled, redistributed and/or sold with any software, provided that each copy contains the above copyright notice and this license. These can be included either as stand-alone text files, human-readable headers or in the appropriate machine-readable metadata fields within text or binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font Name(s) unless explicit written permission is granted by the corresponding Copyright Holder. This restriction only applies to the primary font name as presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font Software shall not be used to promote, endorse or advertise any Modified Version, except to acknowledge the contribution(s) of the Copyright Holder(s) and the Author(s) or with their explicit written permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole, must be distributed entirely under this license, and must not be distributed under any other license. The requirement for fonts to remain under this license does not apply to any document created using the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
+
+      EOS
+
+    end
+  end
+end

--- a/spec/fontist/formulas/montserrat_font_spec.rb
+++ b/spec/fontist/formulas/montserrat_font_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas::MontserratFont do
+  describe "initializing" do
+    it "builds the data dictionary" do
+      formula = Fontist::Formulas::MontserratFont.instance
+
+      expect(formula.fonts.count).to eq(2)
+      expect(formula.fonts.first[:name]).to eq("Montserrat")
+    end
+  end
+
+  describe "installation" do
+    context "with valid licence agreement" do
+      it "installs the valid fonts", skip_in_windows: true do
+        name = "Montserrat"
+        confirmation = "yes"
+
+        stub_fontist_path_to_assets
+        paths = Fontist::Formulas::MontserratFont.fetch_font(
+          name, confirmation: confirmation
+        )
+
+        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(paths.first).to include("fonts/#{name}-Thin.otf")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit imports the `montserrat` formula from the formulas repository. It also added a minor adjustment and also disables the sha verification for this formula. This formulas provides the following fonts:

```
Montserrat-Black.otf
Montserrat-BlackItalic.otf
Montserrat-Bold.otf
Montserrat-BoldItalic.otf
Montserrat-ExtraBold.otf
Montserrat-ExtraBoldItalic.otf
Montserrat-ExtraLight.otf
Montserrat-ExtraLightItalic.otf
Montserrat-Italic.otf
Montserrat-Light.otf
Montserrat-LightItalic.otf
Montserrat-Medium.otf
Montserrat-MediumItalic.otf
Montserrat-Regular.otf
Montserrat-SemiBold.otf
Montserrat-SemiBoldItalic.otf
Montserrat-Thin.otf
Montserrat-ThinItalic.otf
MontserratAlternates-Black.otf
MontserratAlternates-BlackItalic.otf
MontserratAlternates-Bold.otf
MontserratAlternates-BoldItalic.otf
MontserratAlternates-ExtraBold.otf
MontserratAlternates-ExtraBoldItalic.otf
MontserratAlternates-ExtraLight.otf
MontserratAlternates-ExtraLightItalic.otf
MontserratAlternates-Italic.otf
MontserratAlternates-Light.otf
MontserratAlternates-LightItalic.otf
MontserratAlternates-Medium.otf
MontserratAlternates-MediumItalic.otf
MontserratAlternates-Regular.otf
MontserratAlternates-SemiBold.otf
MontserratAlternates-SemiBoldItalic.otf
MontserratAlternates-Thin.otf
MontserratAlternates-ThinItalic.otf
```