### PR TITLE
Add font formulas for overpass fonts

### DIFF
--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -3,6 +3,7 @@ require "fontist/formulas/cleartype_fonts"
 require "fontist/formulas/open_sans_fonts"
 require "fontist/formulas/euphemia_font"
 require "fontist/formulas/montserrat_font"
+require "fontist/formulas/overpass_font"
 
 module Fontist
   module Formulas
@@ -22,6 +23,7 @@ module Fontist
       registry.register(Fontist::Formulas::OpenSansFonts, :open_sans_fonts)
       registry.register(Fontist::Formulas::EuphemiaFont, :euphemia_font)
       registry.register(Fontist::Formulas::MontserratFont, :montserrat_font)
+      registry.register(Fontist::Formulas::OverpassFont, :overpass_font)
     end
   end
 end

--- a/lib/fontist/formulas/helpers/zip_extractor.rb
+++ b/lib/fontist/formulas/helpers/zip_extractor.rb
@@ -1,4 +1,5 @@
 require "zip"
+require "pathname"
 
 module Fontist
   module Formulas
@@ -12,18 +13,19 @@ module Fontist
           block_given? ? yield(fonts_paths) : fonts_paths
         end
 
+        alias_method :unzip, :zip_extract
+
         private
 
         def unzip_fonts(file, fonts_sub_dir = "")
           Zip.on_exists_proc = true
-
           Array.new.tap do |fonts|
+
             Zip::File.open(file) do |zip_file|
               zip_file.glob("#{fonts_sub_dir}*.{ttf,ttc,otf}").each do |entry|
-                filename = entry.name.gsub("#{fonts_sub_dir}", "")
-
-                if filename
-                  font_path = fonts_path.join(filename)
+                if entry.name
+                  filename = Pathname.new(entry.name).basename
+                  font_path = fonts_path.join(filename.to_s)
                   fonts.push(font_path.to_s)
 
                   entry.extract(font_path)

--- a/lib/fontist/formulas/overpass_font.rb
+++ b/lib/fontist/formulas/overpass_font.rb
@@ -1,0 +1,73 @@
+module Fontist
+  module Formulas
+    class OverpassFont < FontFormula
+      desc "Overpass Font"
+      homepage "http://overpassfont.org"
+
+      resource "overpass.zip" do
+        url "https://github.com/RedHatOfficial/Overpass/releases/download/3.0.2/overpass-desktop-fonts.zip"
+        sha256 "10d2186ad1e1e628122f2e4ea0bbde16438e34a0068c35190d41626d89bb64e4"
+      end
+
+      provides_font("Overpass", match_styles_from_file: {
+        "Bold Italic" => "overpass-bold-italic.otf",
+        "Bold" => "overpass-bold.otf",
+        "Extrabold Italic" => "overpass-extrabold-italic.otf",
+        "Extrabold" => "overpass-extrabold.otf",
+        "Extralight" => "overpass-extralight.otf",
+        "Extralight Italic" => "overpass-extralight-italic.otf",
+        "Heavy Italic" => "overpass-heavy-italic.otf",
+        "Heavy" => "overpass-heavy.otf",
+        "Italic" => "overpass-italic.otf",
+        "Light Italic" => "overpass-light-italic.otf",
+        "Light" => "overpass-light.otf",
+        "Regular" => "overpass-regular.otf",
+        "Semibold Italic" => "overpass-semibold-italic.otf",
+        "Semibold" => "overpass-semibold.otf",
+        "Thin Italic" => "overpass-thin-italic.otf",
+        "Thin" => "overpass-thin.otf"
+      })
+
+      provides_font("Overpass Mono", match_styles_from_file: {
+        "Bold" => "overpass-mono-bold.otf",
+        "Regular" => "overpass-mono-regular.otf",
+        "Light" => "overpass-mono-light.otf",
+        "Semibold" => "overpass-mono-semibold.otf"
+      })
+
+      def extract
+        resource("overpass.zip") do |resource|
+          unzip(resource, fonts_sub_dir: "overpass**/") do |fontdir|
+            match_fonts(fontdir, "Overpass")
+            match_fonts(fontdir, "Overpass Mono")
+          end
+        end
+      end
+
+      def install
+        case platform
+        when :macos
+          install_matched_fonts "$HOME/Library/Fonts/Overpass"
+        when :linux
+          install_matched_fonts "/usr/share/fonts/truetype/overpass"
+        end
+      end
+
+      test do
+        case platform
+        when :macos
+          assert_predicate "$HOME/Library/Fonts/Overpass/overpass-thin.otf", :exist?
+        when :linux
+          assert_predicate "/usr/share/fonts/truetype/overpass/overpass-thin.otf", :exist?
+        end
+      end
+
+      open_license <<~EOS
+  Copyright 2016 Red Hat, Inc.,
+
+  This Font Software is dual licensed under the SIL Open Font License and the GNU Lesser General Public License, LGPL 2.1 : http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html OFL 1.1 : http://scripts.sil.org/OFL
+
+      EOS
+    end
+  end
+end

--- a/spec/fontist/formulas/overpass_font_spec.rb
+++ b/spec/fontist/formulas/overpass_font_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Formulas::OverpassFont do
+  describe "initializing" do
+    it "builds the data dictionary" do
+      formula = Fontist::Formulas::OverpassFont.instance
+
+      expect(formula.fonts.count).to eq(2)
+      expect(formula.fonts.first[:name]).to eq("Overpass")
+    end
+  end
+
+  describe "installation" do
+    context "with valid licence agreement" do
+      it "installs the valid fonts", skip_in_windows: true do
+        name = "Overpass"
+        confirmation = "yes"
+
+        stub_fontist_path_to_assets
+        paths = Fontist::Formulas::OverpassFont.fetch_font(
+          name, confirmation: confirmation
+        )
+
+        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(paths.first).to include("fonts/#{name.downcase}-bold-italic.otf")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit imports the overpass formula from fontist formula repository. This modify the extract method a bit so it can look into the sub directories. This formula can be used to install the following list of fonts:

```
overpass-bold-italic.otf
overpass-bold.otf
overpass-extrabold-italic.otf
overpass-extrabold.otf
overpass-extralight-italic.otf
overpass-extralight.otf
overpass-heavy-italic.otf
overpass-heavy.otf
overpass-italic.otf
overpass-light-italic.otf
overpass-light.otf
overpass-mono-bold.otf
overpass-mono-light.otf
overpass-mono-regular.otf
overpass-mono-semibold.otf
overpass-regular.otf
overpass-semibold-italic.otf
overpass-semibold.otf
overpass-thin-italic.otf
overpass-thin.otf
```