### PR TITLE
Add a formulas for the source fonts

### DIFF
--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -4,6 +4,7 @@ require "fontist/formulas/open_sans_fonts"
 require "fontist/formulas/euphemia_font"
 require "fontist/formulas/montserrat_font"
 require "fontist/formulas/overpass_font"
+require "fontist/formulas/source_fonts"
 
 module Fontist
   module Formulas
@@ -24,6 +25,7 @@ module Fontist
       registry.register(Fontist::Formulas::EuphemiaFont, :euphemia_font)
       registry.register(Fontist::Formulas::MontserratFont, :montserrat_font)
       registry.register(Fontist::Formulas::OverpassFont, :overpass_font)
+      registry.register(Fontist::Formulas::SourceFonts, :source_fonts)
     end
   end
 end

--- a/lib/fontist/formulas/source_fonts.rb
+++ b/lib/fontist/formulas/source_fonts.rb
@@ -1,0 +1,109 @@
+module Fontist
+  module Formulas
+    class SourceFonts < FontFormula
+      desc "Adobe Source Fonts"
+      homepage "https://www.adobe.com"
+
+      resource "source-fonts.zip" do
+        url "https://github.com/fontist/source-fonts/releases/download/v1.0/source-fonts-1.0.zip"
+        sha256 "0107b5d4ba305cb4dff2ba19138407aa2153632a2c41592f74d20cd0d0261bfd"
+      end
+
+      provides_font("Source Code Pro", match_styles_from_file: {
+        "Black" => "SourceCodePro-Black.ttf",
+        "Black Italic" => "SourceCodePro-BlackIt.ttf",
+        "Bold" => "SourceCodePro-Bold.ttf",
+        "Bold Italic" => "SourceCodePro-BoldIt.ttf",
+        "Extra Light" => "SourceCodePro-ExtraLight.ttf",
+        "ExtraLightIt" => "SourceCodePro-ExtraLightIt.ttf",
+        "Italic" => "SourceCodePro-It.ttf",
+        "Light" => "SourceCodePro-Light.ttf",
+        "Light Italic" => "SourceCodePro-LightIt.ttf",
+        "Medium" => "SourceCodePro-Medium.ttf",
+        "Medium Italic" => "SourceCodePro-MediumIt.ttf",
+        "Regular" => "SourceCodePro-Regular.ttf",
+        "Semibold" => "SourceCodePro-Semibold.ttf",
+        "Semibold Italic" => "SourceCodePro-SemiboldIt.ttf",
+      })
+
+      provides_font("Source Sans Pro", match_styles_from_file: {
+        "Black" => "SourceSansPro-Black.ttf",
+        "Black Italic" => "SourceSansPro-BlackIt.ttf",
+        "Bold" => "SourceSansPro-Bold.ttf",
+        "Bold Italic" => "SourceSansPro-BoldIt.ttf",
+        "Extra Light" => "SourceSansPro-ExtraLight.ttf",
+        "ExtraLightIt" => "SourceSansPro-ExtraLightIt.ttf",
+        "Italic" => "SourceSansPro-It.ttf",
+        "Light" => "SourceSansPro-Light.ttf",
+        "Light Italic" => "SourceSansPro-LightIt.ttf",
+        "Medium" => "SourceSansPro-Medium.ttf",
+        "Medium Italic" => "SourceSansPro-MediumIt.ttf",
+        "Regular" => "SourceSansPro-Regular.ttf",
+        "Semibold" => "SourceSansPro-Semibold.ttf",
+        "Semibold Italic" => "SourceSansPro-SemiboldIt.ttf",
+      })
+
+      provides_font("Source Serif Pro", match_styles_from_file: {
+        "Black" => "SourceSerifPro-Black.ttf",
+        "Black Italic" => "SourceSerifPro-BlackIt.ttf",
+        "Bold" => "SourceSerifPro-Bold.ttf",
+        "Bold Italic" => "SourceSerifPro-BoldIt.ttf",
+        "Extra Light" => "SourceSerifPro-ExtraLight.ttf",
+        "ExtraLightIt" => "SourceSerifPro-ExtraLightIt.ttf",
+        "Italic" => "SourceSerifPro-It.ttf",
+        "Light" => "SourceSerifPro-Light.ttf",
+        "Light Italic" => "SourceSerifPro-LightIt.ttf",
+        "Medium" => "SourceSerifPro-Medium.ttf",
+        "Medium Italic" => "SourceSerifPro-MediumIt.ttf",
+        "Regular" => "SourceSerifPro-Regular.ttf",
+        "Semibold" => "SourceSerifPro-Semibold.ttf",
+        "Semibold Italic" => "SourceSerifPro-SemiboldIt.ttf",
+      })
+
+      %w(ExtraLight Light Normal Regular Bold Heavy).each do |style|
+        provides_font_collection do |coll|
+          filename "SourceHanSans-#{style}.ttc"
+
+          ["", " TC", " K", " HC", " SC"].each do |variant|
+            provides_font "Source Hans Sans#{variant}", extract_styles_from_collection: {
+              style.to_s => {
+                name: "Source Hans Sans#{variant}",
+                style: style
+              }
+            }
+          end
+        end
+      end
+
+      def extract
+        resource("source-fonts.zip") do |resource|
+          zip_extract(resource, fonts_sub_dir: "fonts/") do |fontdir|
+            match_fonts(fontdir, "Source Code Pro")
+            match_fonts(fontdir, "Source Sans Pro")
+            match_fonts(fontdir, "Source Serif Pro")
+            match_fonts(fontdir, "Source Han Sans")
+          end
+        end
+      end
+
+      def install
+        case platform
+        when :macos
+          install_matched_fonts "$HOME/Library/Fonts/Microsoft"
+        when :linux
+          install_matched_fonts "/usr/share/fonts/truetype/microsoft"
+        end
+      end
+
+      test do
+        case platform
+        when :macos
+          assert_predicate "$HOME/Library/Fonts/Microsoft/tahoma.ttf", :exist?
+        when :linux
+          assert_predicate "/usr/share/fonts/truetype/microsoft/tahoma.ttf", :exist?
+        end
+      end
+
+    end
+  end
+end

--- a/spec/fontist/formulas/euphemia_font_spec.rb
+++ b/spec/fontist/formulas/euphemia_font_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Fontist::Formulas::EuphemiaFont do
 
   describe "installation" do
     context "with valid licence agreement" do
-      it "installs the valid fonts", skip_in_windows: true do
+      it "installs the valid fonts" do
         name = "Euphemia UCAS"
         confirmation = "yes"
 

--- a/spec/fontist/formulas/montserrat_font_spec.rb
+++ b/spec/fontist/formulas/montserrat_font_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Fontist::Formulas::MontserratFont do
 
   describe "installation" do
     context "with valid licence agreement" do
-      it "installs the valid fonts", skip_in_windows: true do
+      it "installs the valid fonts" do
         name = "Montserrat"
         confirmation = "yes"
 

--- a/spec/fontist/formulas/open_sans_fonts_spec.rb
+++ b/spec/fontist/formulas/open_sans_fonts_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Fontist::Formulas::OpenSansFonts do
   end
 
   describe "installation" do
-    context "with valid licence agreement", file_download: true do
-      it "installs the valid fonts", skip_in_windows: true do
+    context "with valid licence agreement" do
+      it "installs the valid fonts" do
         name = "OpenSans"
         confirmation = "yes"
 

--- a/spec/fontist/formulas/source_fonts_spec.rb
+++ b/spec/fontist/formulas/source_fonts_spec.rb
@@ -1,28 +1,30 @@
 require "spec_helper"
 
-RSpec.describe Fontist::Formulas::OverpassFont do
+RSpec.describe Fontist::Formulas::SourceFonts do
   describe "initializing" do
     it "builds the data dictionary" do
-      formula = Fontist::Formulas::OverpassFont.instance
+      formula = Fontist::Formulas::SourceFonts.instance
 
-      expect(formula.fonts.count).to eq(2)
-      expect(formula.fonts.first[:name]).to eq("Overpass")
+      expect(formula.fonts.count).to eq(33)
+      expect(formula.fonts.first[:name]).to eq("Source Code Pro")
     end
   end
 
   describe "installation" do
     context "with valid licence agreement" do
       it "installs the valid fonts" do
-        name = "Overpass"
+        name = "Source Code Pro"
         confirmation = "yes"
 
         stub_fontist_path_to_assets
-        paths = Fontist::Formulas::OverpassFont.fetch_font(
+        paths = Fontist::Formulas::SourceFonts.fetch_font(
           name, confirmation: confirmation
         )
 
         expect(Fontist::Finder.find(name)).not_to be_empty
-        expect(paths.first).to include("fonts/#{name.downcase}-bold-italic.otf")
+        expect(paths).to include(
+          Fontist.fonts_path.join("SourceCodePro-Black.ttf").to_s
+        )
       end
     end
   end


### PR DESCRIPTION
This commit imports the source fonts formula from the fontist formula repository. This also adds a minor adjustment for the fonts sud-directory for zip extractions. On installation this fonts will provides the following fonts with all styles:

```
Source Code Pro
Source Sans Pro
Source Serif Pro
```