### PR TITLE
Simplify the font finding interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,25 @@ gem install fontist
 
 ## Usage
 
-### Find a font
+### Font
 
-The fontist library allows us to easily locate or download a any of the supported
-fonts and then it returns the complete path for the path. To find any font in a
-user's system we can use the following interface.
+The `Fontist::Font` is your go to place to deal with any font using fontist. This
+interface will allow you to find a font or install a font. Lets start with how
+can we find a font in your system.
+
+#### Finding a font
+
+The `Fontist::Fontist.find` interface can be used a find a font in your system.
+It will look into the operating system specific font directories, and also the
+fontist specific `~/.fontist` directory.
 
 ```ruby
-Fontist::Finder.find("Calibri")
+Fontist::Font.find(name)
 ```
+
+If fontist find a font then it will return the paths, but if not found then it
+will could raise an unsupported font error or maybe an installation instruction
+for that specific font.
 
 ### Supported fonts
 

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -5,7 +5,7 @@ require "singleton"
 require "fontist/errors"
 require "fontist/version"
 
-require "fontist/finder"
+require "fontist/font"
 require "fontist/source"
 require "fontist/installer"
 require "fontist/downloader"

--- a/lib/fontist/font.rb
+++ b/lib/fontist/font.rb
@@ -1,5 +1,5 @@
 module Fontist
-  class Finder
+  class Font
     def initialize(name)
       @name = name
     end

--- a/spec/fontist/font_spec.rb
+++ b/spec/fontist/font_spec.rb
@@ -1,34 +1,34 @@
 require "spec_helper"
 
-RSpec.describe Fontist::Finder do
+RSpec.describe Fontist::Font do
   describe ".find" do
     context "with valid font name" do
       it "returns the fonts path" do
         name = "DejaVuSerif.ttf"
         stub_system_font_finder_to_fixture(name)
-        dejavu_ttf = Fontist::Finder.find(name)
+        dejavu_ttf = Fontist::Font.find(name)
 
         expect(dejavu_ttf.first).to include(name)
       end
     end
 
-    context "with downloadable ms vista font" do
-      it "returns missing font error" do
-        name = "Calibri"
+    context "with downloadable font name" do
+      it "raises font missing error" do
+        name = "Courier"
         allow(Fontist::SystemFont).to receive(:find).and_return(nil)
 
         expect {
-          Fontist::Finder.find(name)
+          Fontist::Font.find(name)
         }.to raise_error(Fontist::Errors::MissingFontError)
       end
     end
 
     context "with invalid font name" do
-      it "raise an missing font error" do
+      it "raises font unsupported error" do
         font_name = "InvalidFont.ttf"
 
         expect {
-          Fontist::Finder.find(font_name)
+          Fontist::Font.find(font_name)
         }.to raise_error(Fontist::Errors::NonSupportedFontError)
       end
     end

--- a/spec/fontist/formulas/andale_font_spec.rb
+++ b/spec/fontist/formulas/andale_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::AndaleFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/AndaleMo.TTF")
       end
     end

--- a/spec/fontist/formulas/arial_black_font_spec.rb
+++ b/spec/fontist/formulas/arial_black_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::ArialBlackFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/AriBlk.TTF")
       end
     end

--- a/spec/fontist/formulas/comic_font_spec.rb
+++ b/spec/fontist/formulas/comic_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::ComicFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/Comicbd.TTF")
       end
     end

--- a/spec/fontist/formulas/courier_font_spec.rb
+++ b/spec/fontist/formulas/courier_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::CourierFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/cour.ttf")
       end
     end

--- a/spec/fontist/formulas/euphemia_font_spec.rb
+++ b/spec/fontist/formulas/euphemia_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::EuphemiaFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name} Italic 2.6.6.ttf")
       end
     end

--- a/spec/fontist/formulas/georgia_font_spec.rb
+++ b/spec/fontist/formulas/georgia_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::GeorgiaFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/Georgiaz.TTF")
       end
     end

--- a/spec/fontist/formulas/impact_font_spec.rb
+++ b/spec/fontist/formulas/impact_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::ImpactFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name}.TTF")
       end
     end

--- a/spec/fontist/formulas/montserrat_font_spec.rb
+++ b/spec/fontist/formulas/montserrat_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::MontserratFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name}-Thin.otf")
       end
     end

--- a/spec/fontist/formulas/ms_truetype_fonts_spec.rb
+++ b/spec/fontist/formulas/ms_truetype_fonts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::MsTruetypeFonts do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name}.ttf")
       end
     end

--- a/spec/fontist/formulas/open_sans_fonts_spec.rb
+++ b/spec/fontist/formulas/open_sans_fonts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::OpenSansFonts do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name}-Light.ttf")
       end
     end

--- a/spec/fontist/formulas/overpass_font_spec.rb
+++ b/spec/fontist/formulas/overpass_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::OverpassFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name.downcase}-bold-italic.otf")
       end
     end

--- a/spec/fontist/formulas/source_fonts_spec.rb
+++ b/spec/fontist/formulas/source_fonts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::SourceFonts do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths).to include(
           Fontist.fonts_path.join("SourceCodePro-Black.ttf").to_s
         )

--- a/spec/fontist/formulas/stix_fonts_spec.rb
+++ b/spec/fontist/formulas/stix_fonts_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::StixFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/STIX2Math.otf")
       end
     end

--- a/spec/fontist/formulas/tahoma_font_spec.rb
+++ b/spec/fontist/formulas/tahoma_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::TahomaFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name.downcase}.ttf")
       end
     end

--- a/spec/fontist/formulas/webding_font_spec.rb
+++ b/spec/fontist/formulas/webding_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::WebdingFont do
           name, confirmation: confirmation
         )
 
-        expect(Fontist::Finder.find(name)).not_to be_empty
+        expect(Fontist::Font.find(name)).not_to be_empty
         expect(paths.first).to include("fonts/#{name}.TTF")
       end
     end


### PR DESCRIPTION
Currently, we have a `Fontist::Finder` interface to find a font, which is little bit verbose as it doesn't exactly tell what is it gonna find, a font or a formula?

This commit changes this interface to `Fontist::Font`, so now users can be sure what they are dealing with. This also adds the benefits of having a `install` or `list` interface in future.