### PR TITLE
Add tests for the base font formula

### DIFF
--- a/spec/fontist/font_formula_spec.rb
+++ b/spec/fontist/font_formula_spec.rb
@@ -1,0 +1,67 @@
+require "spec_helper"
+
+RSpec.describe "Fontist::Formulas::DemoFormula" do
+  describe "initialization" do
+    it "registers formula resources through the DSL" do
+      formula = Fontist::Formulas::DemoFormula.instance
+      resource = formula.resources["demo-formula"]
+      demo_font = formula.font_list.first
+
+      expect(formula.key).to eq(:demo_formula)
+      expect(formula.license_required).to be_truthy
+      expect(formula.description).to eq("Demo font formula")
+      expect(formula.license).to eq("Vendor specific font licences")
+      expect(formula.homepage).to eq("https://github.com/fontist/fontist")
+
+      expect(resource[:file_size]).to eq("1234567890")
+      expect(resource[:urls].first).to eq("https://github.com/fontist/fontist")
+      expect(resource[:sha256]).to eq("594e0f42e6581add4dead70c1dfb9")
+
+      expect(demo_font[:styles].count).to eq(2)
+      expect(demo_font[:name]).to eq("Demo font")
+      expect(demo_font[:styles].first[:font]).to eq("demo-font.ttf")
+    end
+  end
+
+  describe "method invokation" do
+    it "invokes the correct method for installation" do
+      expect {
+        Fontist::Formulas::DemoFormula.fetch_font("Demo font", confirmation: "yes")
+      }.not_to raise_error
+    end
+  end
+
+  module Fontist
+    module Formulas
+      class DemoFormula < FontFormula
+        key :demo_formula
+        desc "Demo font formula"
+        homepage "https://github.com/fontist/fontist"
+        requires_license_agreement "Vendor specific font licences"
+
+        resource "demo-formula" do
+          urls [ "https://github.com/fontist/fontist" ]
+          sha256 "594e0f42e6581add4dead70c1dfb9"
+          file_size "1234567890"
+        end
+
+        provides_font "Demo font", match_styles_from_file: {
+          "Regular" => "demo-font.ttf",
+          "Italic" => "demo-fonti.ttf"
+        }
+
+        provides_font_collection("Meiryo Bold") do |coll|
+          filename "demo-font.ttc"
+          provides_font "Demo collection", extract_styles_from_collection: {
+            "Regular" => "demo-col-font.ttf",
+            "Italic" => "demo-col-fonti.ttf"
+          }
+        end
+
+        def extract
+          []
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `FontFormua` in a critical interface for additional formulas to utilize `fontist` specific DSL. This commit adds some necessary tests to ensure the basic requirements are being met.