### PR TITLE
Cleanup the formula related interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ if you do then it will return the paths.
 If you don't but supported by fontist, then it will download the font and copy
 it to `~/.fontist` directory and also return the paths.
 
-```
+```ruby
 Fontist::Font.install(name, confirmation: "no")
 ```
 
@@ -86,6 +86,38 @@ issue then it will raise those errors.
   "Trebuchet",
   "Verdana"
 ]
+```
+
+### Formula
+
+The `fontist` gem internally usages the `Fontist::Formula` interface to find a
+registered formula or fonts supported by any formula. Unless, you need to do
+anything with that you shouldn't need to work with this interface directly. But
+if you do then these are the public interface it offers.
+
+#### Find a formula
+
+The `Fontist::Formula.find` interface allows you to find any of the registered
+formula. This interface takes a font name as an argument and it looks through
+each of the registered formula that offers this font installation. Usages:
+
+```ruby
+Fontist::Formula.find("Calibri")
+```
+
+The above method will find which formula offers this font and then it will
+return a list of the installable formulas that can be used to check licences or
+install that fonts in your system.
+
+#### Find formula fonts
+
+Normally, each font name can be associated with multiple styles or collection, for
+example the `Calibri` font might contains a `regular`, `bola` or `italic` styles
+fonts and if you want a interface that can return the complete list then this is
+your friend. You can use it as following:
+
+```ruby
+Fontist::Formula.find_fonts("Calibri")
 ```
 
 ## Development

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -11,7 +11,7 @@ require "fontist/downloader"
 
 require "fontist/registry"
 require "fontist/formulas"
-require "fontist/formula_finder"
+require "fontist/formula"
 require "fontist/system_font"
 
 module Fontist

--- a/lib/fontist/font.rb
+++ b/lib/fontist/font.rb
@@ -38,7 +38,7 @@ module Fontist
     end
 
     def formulas
-      @formulas ||= Fontist::FormulaFinder.find(name)
+      @formulas ||= Fontist::Formula.find(name)
     end
 
     def downloadable_font

--- a/lib/fontist/font_formula.rb
+++ b/lib/fontist/font_formula.rb
@@ -98,7 +98,7 @@ module Fontist
     end
 
     def map_names_to_fonts(font_name)
-      fonts = FormulaFinder.find_fonts(font_name)
+      fonts = Fontist::Formula.find_fonts(font_name)
       fonts = fonts.map { |font| font.styles.map(&:font) }.flatten if fonts
 
       fonts || []

--- a/lib/fontist/formula.rb
+++ b/lib/fontist/formula.rb
@@ -1,5 +1,5 @@
 module Fontist
-  class FormulaFinder
+  class Formula
     def initialize(font_name)
       @font_name = font_name
     end

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -69,7 +69,7 @@ module Fontist
     end
 
     def map_name_to_valid_font_names
-      fonts =  FormulaFinder.find_fonts(font)
+      fonts =  Formula.find_fonts(font)
       fonts.map { |font| font.styles.map(&:font) }.flatten if fonts
     end
   end

--- a/spec/fontist/formula_spec.rb
+++ b/spec/fontist/formula_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 
-RSpec.describe Fontist::FormulaFinder do
+RSpec.describe Fontist::Formula do
   describe ".find" do
     context "by font name" do
       it "returns the font formulas" do
         name = "Calibri"
 
-        formulas = Fontist::FormulaFinder.find(name)
+        formulas = Fontist::Formula.find(name)
         clear_type = formulas.first
 
         expect(formulas.count).to eq(1)
@@ -20,7 +20,7 @@ RSpec.describe Fontist::FormulaFinder do
       it "returns the font formulas" do
         name = "CAMBRIAI.TTF"
 
-        formulas = Fontist::FormulaFinder.find(name)
+        formulas = Fontist::Formula.find(name)
 
         clear_type = formulas.first
         font_files = clear_type.fonts.map { |font| font.styles.map(&:font) }
@@ -35,7 +35,7 @@ RSpec.describe Fontist::FormulaFinder do
     context "for invalid font" do
       it "returns nil to the caller" do
         name = "Calibri Made Up Name"
-        formulas = Fontist::FormulaFinder.find(name)
+        formulas = Fontist::Formula.find(name)
 
         expect(formulas).to be_nil
       end
@@ -45,7 +45,7 @@ RSpec.describe Fontist::FormulaFinder do
   describe ".find_fonts" do
     it "returns the exact font font names" do
       name = "Calibri"
-      font = Fontist::FormulaFinder.find_fonts(name).last
+      font = Fontist::Formula.find_fonts(name).last
 
       expect(font.styles.map(&:font)).to include("CALIBRI.TTF")
       expect(font.styles.map(&:font)).to include("CALIBRIB.TTF")
@@ -54,7 +54,7 @@ RSpec.describe Fontist::FormulaFinder do
 
     it "returns nil if invalid name provided" do
       name = "Calibri Invlaid"
-      fonts = Fontist::FormulaFinder.find_fonts(name)
+      fonts = Fontist::Formula.find_fonts(name)
 
       expect(fonts).to be_nil
     end


### PR DESCRIPTION
This commit tries to clean up the `Formula` interface. This is more of an internal interface that is being used by fontist, but this commit adds some documentation as well so developer can use this one if necessary.