### PR TITLE
Remove unused temporary asset path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,10 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
-/assets/*
-!/assets/fonts/.keep
+
+# fonts
+/spec/fixtures/fonts/*
+/spec/fixtures/fonts/DejaVuSerif.ttf
 
 # rspec failure tracking
 .rspec_status

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -24,10 +24,6 @@ module Fontist
     Pathname.new(File.dirname(__dir__))
   end
 
-  def self.assets_path
-    Fontist.root_path.join("assets")
-  end
-
   def self.fontist_path
     Pathname.new(Dir.home).join(".fontist")
   end

--- a/spec/fontist/font_spec.rb
+++ b/spec/fontist/font_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Fontist::Font do
       it "installs the font and return the paths" do
         name = "Calibri"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         font_paths = Fontist::Font.install(name, confirmation: "yes")
 
         expect(font_paths.join("|").downcase).to include("#{name.downcase}.ttf")
@@ -49,7 +49,7 @@ RSpec.describe Fontist::Font do
     context "with existing font name" do
       it "returns the existing font paths" do
         name = "Courier"
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         Fontist::Font.install(name, confirmation: "yes")
 
         font_paths = Fontist::Font.install(name, confirmation: "yes")

--- a/spec/fontist/formulas/andale_font_spec.rb
+++ b/spec/fontist/formulas/andale_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::AndaleFont do
         name = "Andale Mono"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::AndaleFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/arial_black_font_spec.rb
+++ b/spec/fontist/formulas/arial_black_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::ArialBlackFont do
         name = "Arial Black"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::ArialBlackFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/comic_font_spec.rb
+++ b/spec/fontist/formulas/comic_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::ComicFont do
         name = "Comic Sans"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::ComicFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/courier_font_spec.rb
+++ b/spec/fontist/formulas/courier_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::CourierFont do
         name = "Courier"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::CourierFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/euphemia_font_spec.rb
+++ b/spec/fontist/formulas/euphemia_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::EuphemiaFont do
         name = "Euphemia UCAS"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::EuphemiaFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/georgia_font_spec.rb
+++ b/spec/fontist/formulas/georgia_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::GeorgiaFont do
         name = "Georgia"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::GeorgiaFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/impact_font_spec.rb
+++ b/spec/fontist/formulas/impact_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::ImpactFont do
         name = "Impact"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::ImpactFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/montserrat_font_spec.rb
+++ b/spec/fontist/formulas/montserrat_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::MontserratFont do
         name = "Montserrat"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::MontserratFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/ms_truetype_fonts_spec.rb
+++ b/spec/fontist/formulas/ms_truetype_fonts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::MsTruetypeFonts do
         name = "Arial"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::MsTruetypeFonts.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/open_sans_fonts_spec.rb
+++ b/spec/fontist/formulas/open_sans_fonts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::OpenSansFonts do
         name = "OpenSans"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::OpenSansFonts.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/overpass_font_spec.rb
+++ b/spec/fontist/formulas/overpass_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::OverpassFont do
         name = "Overpass"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::OverpassFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/source_fonts_spec.rb
+++ b/spec/fontist/formulas/source_fonts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::SourceFonts do
         name = "Source Code Pro"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::SourceFonts.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/stix_fonts_spec.rb
+++ b/spec/fontist/formulas/stix_fonts_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::StixFont do
         name = "STIX Two Math"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::StixFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/tahoma_font_spec.rb
+++ b/spec/fontist/formulas/tahoma_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::TahomaFont do
         name = "Tahoma"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::TahomaFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/fontist/formulas/webding_font_spec.rb
+++ b/spec/fontist/formulas/webding_font_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Fontist::Formulas::WebdingFont do
         name = "Webdings"
         confirmation = "yes"
 
-        stub_fontist_path_to_assets
+        stub_fontist_path_to_temp_path
         paths = Fontist::Formulas::WebdingFont.fetch_font(
           name, confirmation: confirmation
         )

--- a/spec/support/fontist_helper.rb
+++ b/spec/support/fontist_helper.rb
@@ -1,7 +1,9 @@
 module Fontist
   module Helper
-    def stub_fontist_path_to_assets
-      allow(Fontist).to receive(:fontist_path).and_return(Fontist.assets_path)
+    def stub_fontist_path_to_temp_path
+      allow(Fontist).to receive(:fontist_path).and_return(
+        Fontist.root_path.join("spec", "fixtures")
+      )
     end
   end
 end


### PR DESCRIPTION
Since we've created the `~/.fontist` global directory we are not using the `assets/fonts` folder anymore. But there are some tests that are still using the folder for temporary assets.

This commit removes this folder structure and updates the tests to use the fixtures folder for the temporary test-related files