### PR TITLE
Skip option for slow test locally

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -27,4 +27,4 @@ jobs:
         run: bin/setup
 
       - name: Run tests
-        run: bin/rspec
+        run: TEST_ENV=CI bin/rspec

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,4 +27,4 @@ jobs:
         run: bin/setup
 
       - name: Run tests
-        run: bin/rspec
+        run: TEST_ENV=CI bin/rspec

--- a/spec/fontist/downloader_spec.rb
+++ b/spec/fontist/downloader_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 RSpec.describe Fontist::Downloader do
-  describe ".download", file_download: true do
+  describe ".download" do
     it "return the valid downloaded file" do
       tempfile = Fontist::Downloader.download(
         sample_file[:file],

--- a/spec/fontist/formulas/andale_font_spec.rb
+++ b/spec/fontist/formulas/andale_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::AndaleFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Andale Mono"
         confirmation = "yes"

--- a/spec/fontist/formulas/arial_black_font_spec.rb
+++ b/spec/fontist/formulas/arial_black_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::ArialBlackFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Arial Black"
         confirmation = "yes"

--- a/spec/fontist/formulas/cleartype_fonts_spec.rb
+++ b/spec/fontist/formulas/cleartype_fonts_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Fontist::Formulas::ClearTypeFonts do
   end
 
   describe "installation" do
-    context "with valid licence agreement", file_download: true do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Calibri"
         confirmation = "yes"

--- a/spec/fontist/formulas/comic_font_spec.rb
+++ b/spec/fontist/formulas/comic_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::ComicFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Comic Sans"
         confirmation = "yes"

--- a/spec/fontist/formulas/courier_font_spec.rb
+++ b/spec/fontist/formulas/courier_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::CourierFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Courier"
         confirmation = "yes"

--- a/spec/fontist/formulas/georgia_font_spec.rb
+++ b/spec/fontist/formulas/georgia_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::GeorgiaFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Georgia"
         confirmation = "yes"

--- a/spec/fontist/formulas/impact_font_spec.rb
+++ b/spec/fontist/formulas/impact_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::ImpactFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Impact"
         confirmation = "yes"

--- a/spec/fontist/formulas/montserrat_font_spec.rb
+++ b/spec/fontist/formulas/montserrat_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::MontserratFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts" do
         name = "Montserrat"
         confirmation = "yes"

--- a/spec/fontist/formulas/open_sans_fonts_spec.rb
+++ b/spec/fontist/formulas/open_sans_fonts_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::OpenSansFonts do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts" do
         name = "OpenSans"
         confirmation = "yes"

--- a/spec/fontist/formulas/source_fonts_spec.rb
+++ b/spec/fontist/formulas/source_fonts_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::SourceFonts do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts" do
         name = "Source Code Pro"
         confirmation = "yes"

--- a/spec/fontist/formulas/tahoma_font_spec.rb
+++ b/spec/fontist/formulas/tahoma_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::TahomaFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Tahoma"
         confirmation = "yes"

--- a/spec/fontist/formulas/webding_font_spec.rb
+++ b/spec/fontist/formulas/webding_font_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Fontist::Formulas::WebdingFont do
   end
 
   describe "installation" do
-    context "with valid licence agreement" do
+    context "with valid licence agreement", slow: true do
       it "installs the valid fonts", skip_in_windows: true do
         name = "Webdings"
         confirmation = "yes"

--- a/spec/fontist/system_font_spec.rb
+++ b/spec/fontist/system_font_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe Fontist::SystemFont do
     end
 
     context "with valid font name" do
-      it "returns the complete font path", file_download: true do
-        name = "Courier"
-        stub_fontist_path_to_assets
-        Fontist::Formulas::CourierFont.fetch_font(name, confirmation: "yes")
+      it "returns the complete font path", slow: true do
+        name = "Calibri"
+        stub_fontist_path_to_temp_path
+        Fontist::Formulas::ClearTypeFonts.fetch_font(name, confirmation: "yes")
 
-        courier = Fontist::SystemFont.find(name, sources: [font_sources])
-        expect(courier.first).to include("cour.ttf")
+        calbiri = Fontist::SystemFont.find(name, sources: [font_sources])
+        expect(calbiri.join("|").downcase).to include("#{name.downcase}.ttf")
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,8 +11,10 @@ RSpec.configure do |config|
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
 
-  # Skip the actual file_download by default
-  config.filter_run_excluding file_download: true
+  # Skip the slow tests locally
+  unless ENV.fetch("TEST_ENV", "local").upcase === "CI"
+    config.filter_run_excluding slow: true
+  end
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
There are a couple of tests that runs super slow, which mainly depends on the host for those formulas. So, unless we did any
changes on those formulas we don't necessarily break those

This commit adds a mechanism by adding a rspec tag `slow_test`, so by default `bin/rspec` will ignore those slow tests. But it
will running the same as before in the CI environment.