### PR TITLE
Add support to list all available fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,29 +64,18 @@ Fontist::Font.install(name, confirmation: "no")
 If there are some issue with the provided font, like not supported or some other
 issue then it will raise those errors.
 
-### Supported fonts
+#### List all fonts
+
+The `Fontist::Font` interface exposes an interface to list all supported fonts,
+this might be useful if want to know the name of the font or the available
+styles. You can do that by using:
 
 ```ruby
-[
-  "Arial",
-  "Calibri",
-  "Cambria",
-  "Candara",
-  "Consola",
-  "Constantia",
-  "Corbel",
-  "Courier",
-  "Meiryo",
-  "Meiryo UI",
-  "Source Code Pro",
-  "Source Han Sans",
-  "Source Sans Pro",
-  "Source Serif Pro",
-  "Times New Roman",
-  "Trebuchet",
-  "Verdana"
-]
+Fontist::Font.all
 ```
+
+The return values are ` OpenStruct` object, so you can easily do any other
+operation you would do in any ruby object.
 
 ### Formula
 
@@ -119,6 +108,21 @@ your friend. You can use it as following:
 ```ruby
 Fontist::Formula.find_fonts("Calibri")
 ```
+
+
+#### List all formulas
+
+The `Fontist::Formula` interface exposes an interface to list all registered
+font formula. This might be useful if want to know the name of the formula or
+what type fonts can be installed using that formula. Usages:
+
+```ruby
+Fontist::Formula.all
+```
+
+The return values are ` OpenStruct` object, so you can easily do any other
+operation you would do in any ruby object.
+
 
 ## Development
 

--- a/lib/fontist/font.rb
+++ b/lib/fontist/font.rb
@@ -1,16 +1,20 @@
 module Fontist
   class Font
-    def initialize(name, options = {})
-      @name = name
+    def initialize(options = {})
+      @name = options.fetch(:name, nil)
       @confirmation = options.fetch(:confirmation, "no")
     end
 
+    def self.all
+      new.all
+    end
+
     def self.find(name)
-      new(name).find
+      new(name: name).find
     end
 
     def self.install(name, confirmation: "no")
-      new(name, confirmation: confirmation).install
+      new(name: name, confirmation: confirmation).install
     end
 
     def find
@@ -23,6 +27,10 @@ module Fontist
       find_system_font || download_font || raise(
         Fontist::Errors::NonSupportedFontError
       )
+    end
+
+    def all
+      Fontist::Formula.all.to_h.map { |_name, formula| formula.fonts }.flatten
     end
 
     private

--- a/spec/fontist/font_spec.rb
+++ b/spec/fontist/font_spec.rb
@@ -1,6 +1,16 @@
 require "spec_helper"
 
 RSpec.describe Fontist::Font do
+  describe ".all" do
+    it "list all supported fonts" do
+      fonts = Fontist::Font.all
+
+      expect(fonts.count).to be > 10
+      expect(fonts.first.name).not_to be_nil
+      expect(fonts.first.styles).not_to be_nil
+    end
+  end
+
   describe ".find" do
     context "with valid font name" do
       it "returns the fonts path" do


### PR DESCRIPTION
This commit adds an interface to the `Fontist::Font` interface that will allow a user to list out all of the supported fonts.
The interface doesn't need any parameter, and you can simply do the following to list fonts:

```ruby
Fontist::Font.all
```