### PR TITLE
Fix loading issue for font formulas

### DIFF
--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -31,4 +31,20 @@ module Fontist
   def self.fonts_path
     Fontist.fontist_path.join("fonts")
   end
+
+  def self.formulas_path
+    Fontist.lib_path.join("fontist", "formulas")
+  end
 end
+
+# Loading formulas
+#
+# The formula loading behavior is dynamic, so what we are actualy
+# doing here is looking for formulas in the `./fontist/formulas` directory
+# then require thos as we go.
+#
+# There is a caviat, since the `Dir` method depends on absoulate path
+# so moving this loading up or somewhere else might not always ensure
+# the fontist related path helpers.
+#
+Dir[Fontist.formulas_path.join("**.rb").to_s].sort.each { |file| require file }

--- a/lib/fontist/formulas.rb
+++ b/lib/fontist/formulas.rb
@@ -1,6 +1,5 @@
 require "fontist/utils"
 require "fontist/font_formula"
-Dir["./lib/fontist/formulas/**.rb"].sort.each { |file| require file }
 
 module Fontist
   module Formulas


### PR DESCRIPTION
The dynamic font formulas loading was not working as expected, it was mainly because of the relative paths we were using to require those files. This commit changes this to absolute paths, and also move the dynamic loading to `fontist.rb` file.