### PR TITLE
Add randomization to select a file URL

### DIFF
--- a/lib/fontist/downloader.rb
+++ b/lib/fontist/downloader.rb
@@ -11,7 +11,10 @@ module Fontist
       file = download_file
 
       if sha && Digest::SHA256.file(file) != sha
-        raise(Fontist::Errors::TemparedFileError)
+        raise(Fontist::Errors::TemparedFileError.new(
+          "The downloaded file from #{@file} doesn't " \
+          "match with the expected sha256 checksum!"
+        ))
       end
 
       file
@@ -46,6 +49,9 @@ module Fontist
           bar.increment(progress / byte_to_megabyte) if @progress === true
         }
       )
+
+    rescue Down::NotFound
+      raise(Fontist::Errors::InvalidResourceError.new("Invalid URL: #{@file}"))
     end
   end
 

--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -4,5 +4,6 @@ module Fontist
     class MissingFontError < StandardError; end
     class NonSupportedFontError < StandardError; end
     class TemparedFileError < StandardError; end
+    class InvalidResourceError < StandardError; end
   end
 end

--- a/lib/fontist/font_formula.rb
+++ b/lib/fontist/font_formula.rb
@@ -106,7 +106,7 @@ module Fontist
 
     def download_file(source)
       downloaded_file = Fontist::Downloader.download(
-        source[:urls].first, sha: source[:sha256], file_size: source[:file_size]
+        source[:urls].sample, sha: source[:sha256], file_size: source[:file_size]
       )
 
       @downloaded = true

--- a/lib/fontist/formulas/cleartype_fonts.rb
+++ b/lib/fontist/formulas/cleartype_fonts.rb
@@ -7,10 +7,8 @@ module Fontist
 
       resource "PowerPointViewer.exe" do
         urls [
-          "https://www.dropbox.com/s/dl/6lclhxpydwgkjzh/PowerPointViewer.exe?dl=1",
           "https://web.archive.org/web/20171225132744/http://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe",
           "https://archive.org/download/PowerPointViewer_201801/PowerPointViewer.exe",
-          "https://files.giga-downloads.de/office/PowerPointViewer.exe"
         ]
         sha256 "249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423"
         file_size "62914560"

--- a/lib/fontist/formulas/ms_truetype_fonts.rb
+++ b/lib/fontist/formulas/ms_truetype_fonts.rb
@@ -7,7 +7,6 @@ module Fontist
       resource "EUupdate.EXE" do
         urls [
           "https://download.microsoft.com/download/a/1/8/a180e21e-9c2b-4b54-9c32-bf7fd7429970/EUupdate.EXE",
-          "https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/EUupdate.EXE"
         ]
         sha256 "464dd2cd5f09f489f9ac86ea7790b7b8548fc4e46d9f889b68d2cdce47e09ea8"
       end


### PR DESCRIPTION
Currently, we are selecting the first URL to download any of the source files, but that might some cause some issues sometimes. So, this commit changes this to take a random one from the list and it should not always send the traffic to one source.