### PR TITLE
Fix return type for formula finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Fontist::Formula.find("Calibri")
 ```
 
 The above method will find which formula offers this font and then it will
-return a list of the installable formulas that can be used to check licences or
-install that fonts in your system.
+return a installable formula that can be used to check licences or install that
+fonts in your system.
 
 #### Find formula fonts
 

--- a/lib/fontist/font.rb
+++ b/lib/fontist/font.rb
@@ -45,12 +45,12 @@ module Fontist
       Object.const_get(formula.installer)
     end
 
-    def formulas
-      @formulas ||= Fontist::Formula.find(name)
+    def formula
+      @formula ||= Fontist::Formula.find(name)
     end
 
     def downloadable_font
-      unless formulas.nil?
+      if formula
         raise(
           Fontist::Errors::MissingFontError,
           "Fonts are missing, please run " \
@@ -61,10 +61,8 @@ module Fontist
     end
 
     def download_font
-      unless formulas.nil?
-        formulas.map do |formula|
-          font_installer(formula).fetch_font(name, confirmation: confirmation)
-        end.flatten
+      if formula
+        font_installer(formula).fetch_font(name, confirmation: confirmation)
       end
     end
   end

--- a/lib/fontist/formula.rb
+++ b/lib/fontist/formula.rb
@@ -23,8 +23,7 @@ module Fontist
     end
 
     def find
-      formulas = [find_formula].flatten
-      formulas.empty? ? nil : formulas
+      [find_formula].flatten.first
     end
 
     def find_fonts

--- a/spec/fontist/formula_spec.rb
+++ b/spec/fontist/formula_spec.rb
@@ -6,10 +6,8 @@ RSpec.describe Fontist::Formula do
       it "returns the font formulas" do
         name = "Calibri"
 
-        formulas = Fontist::Formula.find(name)
-        clear_type = formulas.first
+        clear_type = Fontist::Formula.find(name)
 
-        expect(formulas.count).to eq(1)
         expect(clear_type.fonts.map(&:name)).to include(name)
         expect(clear_type.installer).to eq("Fontist::Formulas::ClearTypeFonts")
         expect(clear_type.description).to include("Microsoft ClearType Fonts")
@@ -20,12 +18,9 @@ RSpec.describe Fontist::Formula do
       it "returns the font formulas" do
         name = "CAMBRIAI.TTF"
 
-        formulas = Fontist::Formula.find(name)
-
-        clear_type = formulas.first
+        clear_type = Fontist::Formula.find(name)
         font_files = clear_type.fonts.map { |font| font.styles.map(&:font) }
 
-        expect(formulas.count).to eq(1)
         expect(font_files.flatten).to include(name)
         expect(clear_type.installer).to eq("Fontist::Formulas::ClearTypeFonts")
         expect(clear_type.description).to include("Microsoft ClearType Fonts")


### PR DESCRIPTION
The `Fontist::Formula.find` method returns a list of formulas, but in reality, it's always one or should be one formula that is
expected from this interface. So this commit changes this and it also adjusts the font installer to adopt these changes.