### PR TITLE
Add new URLs for clear type formula

### DIFF
--- a/lib/fontist/downloader.rb
+++ b/lib/fontist/downloader.rb
@@ -1,16 +1,16 @@
 module Fontist
   class Downloader
     def initialize(file, file_size: nil, sha: nil, progress: nil)
-      @sha = sha
       @file = file
       @progress = progress
+      @sha = [sha].flatten.compact
       @file_size = (file_size || default_file_size).to_i
     end
 
     def download
       file = download_file
 
-      if sha && Digest::SHA256.file(file) != sha
+      if !sha.empty? && !sha.include?(Digest::SHA256.file(file).to_s)
         raise(Fontist::Errors::TemparedFileError.new(
           "The downloaded file from #{@file} doesn't " \
           "match with the expected sha256 checksum!"

--- a/lib/fontist/formulas/cleartype_fonts.rb
+++ b/lib/fontist/formulas/cleartype_fonts.rb
@@ -7,10 +7,17 @@ module Fontist
 
       resource "PowerPointViewer.exe" do
         urls [
+          "https://nchc.dl.sourceforge.net/project/mscorefonts2/cabs/PowerPointViewer.exe",
+          "https://sourceforge.net/projects/mscorefonts2/files/cabs/PowerPointViewer.exe/download",
           "https://web.archive.org/web/20171225132744/http://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe",
-          "https://archive.org/download/PowerPointViewer_201801/PowerPointViewer.exe",
+          "https://archive.org/download/PowerPointViewer_201801/PowerPointViewer.exe"
         ]
-        sha256 "249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423"
+
+        sha256 [
+          "249473568eba7a1e4f95498acba594e0f42e6581add4dead70c1dfb908a09423",
+          "c4e753548d3092ffd7dd3849105e0a26d9b5a1afe46e6e667fe7c6887893701f",
+        ]
+
         file_size "62914560"
       end
 


### PR DESCRIPTION
This commit adds new resource URL's for the clear type fonts, This commit also extends the existing SHA verification, so now
we can also pass an array for the checksum, so it will use the list for verifications.

closes #64 