### PR TITLE
Ensure fontist related paths are presents

### DIFF
--- a/lib/fontist/font.rb
+++ b/lib/fontist/font.rb
@@ -3,6 +3,8 @@ module Fontist
     def initialize(options = {})
       @name = options.fetch(:name, nil)
       @confirmation = options.fetch(:confirmation, "no")
+
+      check_or_create_fontist_path!
     end
 
     def self.all
@@ -39,6 +41,13 @@ module Fontist
 
     def find_system_font
       Fontist::SystemFont.find(name)
+    end
+
+    def check_or_create_fontist_path!
+      unless Fontist.fonts_path.exist?
+        require "fileutils"
+        FileUtils.mkdir_p(Fontist.fonts_path)
+      end
     end
 
     def font_installer(formula)

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -3,8 +3,6 @@ module Fontist
     def initialize(font:, sources: nil)
       @font = font
       @user_sources = sources || []
-
-      check_or_create_fontist_path
     end
 
     def self.find(font, sources: [])
@@ -21,13 +19,6 @@ module Fontist
     private
 
     attr_reader :font, :user_sources
-
-    def check_or_create_fontist_path
-      unless fontist_fonts_path.exist?
-        require "fileutils"
-        FileUtils.mkdir_p(fontist_fonts_path)
-      end
-    end
 
     def font_paths
       Dir.glob((


### PR DESCRIPTION
The fontist gem requires the `~/.fontist` directory to function properly. Earlier, we are checking this one in system font check
but we actually might need that for font lookup or installation so this commit moves this login to `Fontist::Font` interface, so
any call to this interface will create those missing directories