### PR TITLE
Fix system font finder related issues

### DIFF
--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -29,8 +29,8 @@ module Fontist
     end
 
     def lookup_using_font_name
-      font_names = map_name_to_valid_font_names
-      font_paths.grep(/#{font_names.join("|")}/i) if font_names
+      font_names = map_name_to_valid_font_names || []
+      font_paths.grep(/#{font_names.join("|")}/i) unless font_names.empty?
     end
 
     def fontist_fonts_path

--- a/spec/fontist/system_font_spec.rb
+++ b/spec/fontist/system_font_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Fontist::SystemFont do
     end
 
     context "with invalid font" do
+      it "returns nil for partial-not match" do
+        name = "Deje"
+        expect(Fontist::SystemFont.find(name)).to be_nil
+      end
+
       it "returns nill to the caller" do
         name = "invalid-font.ttf"
         invalid_font = Fontist::SystemFont.find(name, sources: [font_sources])


### PR DESCRIPTION
The system font finder was returning the whole list of fonts for some cases like `Calib`, turns out it was a validation check for the font names, it returns empty array & that's what was causing this issue.

This commit fixes this issue, and also adds a small check for this so now we only return the matched list of fonts.