### PR TITLE
Add a time limit for the slow formulas

### DIFF
--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -5,5 +5,6 @@ module Fontist
     class NonSupportedFontError < StandardError; end
     class TemparedFileError < StandardError; end
     class InvalidResourceError < StandardError; end
+    class TimeoutError < StandardError; end
   end
 end

--- a/lib/fontist/utils/downloader.rb
+++ b/lib/fontist/utils/downloader.rb
@@ -46,6 +46,8 @@ module Fontist
 
         Down.download(
           @file,
+          open_timeout: 10,
+          read_timeout: 10,
           progress_proc: -> (progress) {
             bar.increment(progress / byte_to_megabyte) if @progress_bar === true
           }


### PR DESCRIPTION
There are some formulas that might be super slow sometime, and that leaves the user with a feeling of stalling, so this commit adds a time caps to each slow download, by default it's 20 seconds and if the download is done then it closes that request.

Fair warning, the `Timeout` module doesn't have a very good reputation but for our use cases this seems to work for now, but we really should keep an eye on it for future improvement.

Fixes #96
Link: https://github.com/ankane/the-ultimate-guide-to-ruby-timeouts