### PR TITLE
Fix type for the Tampered error class

### DIFF
--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -3,7 +3,7 @@ module Fontist
     class LicensingError < StandardError; end
     class MissingFontError < StandardError; end
     class NonSupportedFontError < StandardError; end
-    class TemparedFileError < StandardError; end
+    class TamperedFileError < StandardError; end
     class InvalidResourceError < StandardError; end
     class TimeoutError < StandardError; end
   end

--- a/lib/fontist/utils/downloader.rb
+++ b/lib/fontist/utils/downloader.rb
@@ -12,7 +12,7 @@ module Fontist
         file = download_file
 
         if !sha.empty? && !sha.include?(Digest::SHA256.file(file).to_s)
-          raise(Fontist::Errors::TemparedFileError.new(
+          raise(Fontist::Errors::TamperedFileError.new(
             "The downloaded file from #{@file} doesn't " \
             "match with the expected sha256 checksum!"
           ))

--- a/spec/fontist/utils/downloader_spec.rb
+++ b/spec/fontist/utils/downloader_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Fontist::Utils::Downloader do
           sha: sample_file[:sha] + "mm",
           file_size: sample_file[:file_size]
         )
-      }.to raise_error(Fontist::Errors::TemparedFileError)
+      }.to raise_error(Fontist::Errors::TamperedFileError)
     end
   end
 


### PR DESCRIPTION
This commit fixes the type for the Tampered error class, and it also updates the necessary downloader and their specs to adopt these changes.

Fixes #99