### PR TITLE
Adjust default font lookup paths

### DIFF
--- a/lib/fontist/system.yml
+++ b/lib/fontist/system.yml
@@ -6,6 +6,7 @@ system:
   windows:
     paths:
       - C:/Windows/Fonts/**/**.{ttc,ttf}
+      - C:/Users/{username}/AppData/Local/Microsoft/Windows/Fonts/**/**.{ttc,ttf}
 
   macos:
     paths:

--- a/lib/fontist/system.yml
+++ b/lib/fontist/system.yml
@@ -11,6 +11,7 @@ system:
     paths:
       - /Library/Fonts/**/**.{ttf,ttc}
       - /System/Library/Fonts/**/**.{ttf,ttc}
+      - /Users/{username}/Library/Fonts/**.{ttf,ttc}
       - /Applications/Microsoft**/Contents/Resources/**/**.{ttf,ttc}
 
   unix:

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -20,10 +20,19 @@ module Fontist
 
     attr_reader :font, :user_sources
 
+    def normalize_default_paths
+      @normalize_default_paths ||= default_sources["paths"].map do |path|
+        require "etc"
+        passwd = Etc.getpwuid
+
+        passwd ? path.gsub("{username}", passwd.name) : path
+      end
+    end
+
     def font_paths
       Dir.glob((
         user_sources +
-        default_sources["paths"] +
+        normalize_default_paths +
         [fontist_fonts_path.join("**")]
       ).flatten.uniq)
     end


### PR DESCRIPTION
This commit updates the default font lookup paths for the Mac OS, this also adds some normalization to replace username
variable with the correct system user's name.

Related #95 