### PR TITLE
Add support for license agreement handling

### DIFF
--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "down", "~> 5.0"
   spec.add_runtime_dependency "libmspack", "~> 0.1.0"
   spec.add_runtime_dependency "rubyzip", "~> 2.3.0"
+  spec.add_runtime_dependency "thor", "~> 1.0.1"
 
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 2.0"

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -14,6 +14,10 @@ require "fontist/formula"
 require "fontist/system_font"
 
 module Fontist
+  def self.ui
+    Fontist::Utils::UI
+  end
+
   def self.lib_path
     Fontist.root_path.join("lib")
   end

--- a/lib/fontist/font.rb
+++ b/lib/fontist/font.rb
@@ -62,9 +62,9 @@ module Fontist
       if formula
         raise(
           Fontist::Errors::MissingFontError,
-          "Fonts are missing, please run " \
+"#{name}"          "Fonts are missing, please run " \
           "Fontist::Font.install('#{name}', confirmation: 'yes') to " \
-          "download the font"
+          "download the font."
         )
       end
     end
@@ -82,7 +82,7 @@ module Fontist
 
         if !confirmation.casecmp("yes").zero?
           raise Fontist::Errors::LicensingError.new(
-            "We can't downlod these fonts unless you accept the terms."
+            "Fontist will not download these fonts unless you accept the terms."
           )
         end
       end
@@ -98,14 +98,9 @@ module Fontist
 
     def license_agrement_message(license)
       <<~MSG
-        FONT LICENSE ACCEPTANCE REQUIRED:
+        FONT LICENSE ACCEPTANCE REQUIRED FOR "#{name}":
 
-        Fontist has detected that you do not have the necessary fonts installed
-        for PDF generation. Without those fonts, the generated PDF will use
-        generic fonts that may not resemble the desired styling.
-
-        Fontist can download these files for you if you accept the font
-        licensing conditions for the font "#{name}".
+        Fontist can install this font if you accept its licensing conditions.
 
         FONT LICENSE BEGIN ("#{name}")
         -----------------------------------------------------------------------

--- a/lib/fontist/font.rb
+++ b/lib/fontist/font.rb
@@ -71,8 +71,48 @@ module Fontist
 
     def download_font
       if formula
+        check_and_confirm_required_license(formula)
         font_installer(formula).fetch_font(name, confirmation: confirmation)
       end
+    end
+
+    def check_and_confirm_required_license(formula)
+      if formula.license_required && !confirmation.casecmp("yes").zero?
+        @confirmation = show_license_and_ask_for_input(formula.license)
+
+        if !confirmation.casecmp("yes").zero?
+          raise Fontist::Errors::LicensingError.new(
+            "We can't downlod these fonts unless you accept the terms."
+          )
+        end
+      end
+    end
+
+    def show_license_and_ask_for_input(license)
+      Fontist.ui.say(license_agrement_message(license))
+      Fontist.ui.ask(
+        "\nDo you accept all presented font licenses, and want Fontist " \
+        "to download these fonts for you? => TYPE 'Yes' or 'No':"
+      )
+    end
+
+    def license_agrement_message(license)
+      <<~MSG
+        FONT LICENSE ACCEPTANCE REQUIRED:
+
+        Fontist has detected that you do not have the necessary fonts installed
+        for PDF generation. Without those fonts, the generated PDF will use
+        generic fonts that may not resemble the desired styling.
+
+        Fontist can download these files for you if you accept the font
+        licensing conditions for the font "#{name}".
+
+        FONT LICENSE BEGIN ("#{name}")
+        -----------------------------------------------------------------------
+        #{license}
+        -----------------------------------------------------------------------
+        FONT LICENSE END ("#{name}")
+      MSG
     end
   end
 end

--- a/lib/fontist/registry.rb
+++ b/lib/fontist/registry.rb
@@ -32,6 +32,7 @@ module Fontist
         license: formula.instance.license,
         homepage: formula.instance.homepage ,
         description: formula.instance.description,
+        license_required: formula.instance.license_required,
       }
     end
 

--- a/lib/fontist/utils.rb
+++ b/lib/fontist/utils.rb
@@ -1,3 +1,4 @@
+require "fontist/utils/ui"
 require "fontist/utils/dsl"
 require "fontist/utils/downloader"
 require "fontist/utils/zip_extractor"

--- a/lib/fontist/utils/downloader.rb
+++ b/lib/fontist/utils/downloader.rb
@@ -4,8 +4,8 @@ module Fontist
       def initialize(file, file_size: nil, sha: nil, progress_bar: nil)
         # TODO: If the first mirror fails, try the second one
         @file = file
-        @progress_bar = progress_bar
         @sha = [sha].flatten.compact
+        @progress_bar = set_progress_bar(progress_bar)
         @file_size = (file_size || default_file_size).to_i
       end
 
@@ -40,6 +40,10 @@ module Fontist
 
       def download_path
         options[:download_path] || Fontist.root_path.join("tmp")
+      end
+
+      def set_progress_bar(progress_bar)
+        ENV.fetch("TEST_ENV", "") === "CI" ? false : progress_bar
       end
 
       def download_file

--- a/lib/fontist/utils/ui.rb
+++ b/lib/fontist/utils/ui.rb
@@ -1,0 +1,15 @@
+require "thor"
+
+module Fontist
+  module Utils
+    class UI < Thor
+      def self.say(message)
+        new.say(message)
+      end
+
+      def self.ask(message, options = {})
+        new.ask(message, options)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Earlier, Fontist wasn't handling the proprietary license itself, but relying on the dependent client library to handle it for us.
But we've decided to handle the required license by fontist, so this commit adds the support for that.

There are a couple of scenarios: first of all, the open fonts, and in those case fontist won't prompt the license agreement and it will install the font from the correct formula.

The second scenario, proprietary font with required license, and in this case fontist will display the license and ask the user to
provide their confirmation, and if it is the same as the required one then it will proceed or raise an error.

Fair warning: this might cause some issue if someone tries to use fontist for some automation, where they don't provide the
correct license, but that's what we are trying to avoid and want the client to handle it properly.

Fixes #98 