### PR TITLE
Fix Han Sans installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ Gemfile.lock
 /spec/fixtures/fonts/DejaVuSerif.ttf
 /spec/fixtures/formulas/
 /spec/fixtures/*
+!/spec/fixtures/system.yml
 
 # rspec failure tracking
 .rspec_status
+
+# remote file cache
+.rubocop-*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+inherit_from:
+  - 'https://raw.githubusercontent.com/fontist/oss-guides/master/ci/rubocop.yml'
+
 AllCops:
   Exclude:
     - 'lib/fontist/import/google/fonts_public.pb.rb'

--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -39,5 +39,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "0.75.0"
+  spec.add_development_dependency "rubocop-rails"
+  spec.add_development_dependency "rubocop-performance"
   spec.add_development_dependency "ruby-protocol-buffers", "~> 1.0"
 end

--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -50,4 +50,8 @@ module Fontist
   def self.downloads_path
     Fontist.fontist_path.join("downloads")
   end
+
+  def self.system_file_path
+    Fontist.lib_path.join("fontist", "system.yml")
+  end
 end

--- a/lib/fontist/fontist_font.rb
+++ b/lib/fontist/fontist_font.rb
@@ -1,34 +1,70 @@
 module Fontist
   class FontistFont
-    def initialize(font:)
-      @font = font
+    def initialize(font_name:)
+      @font_name = font_name
+
+      check_and_register_font_formulas
     end
 
-    def self.find(font)
-      new(font: font).find
+    def self.find(name)
+      new(font_name: name).find
     end
 
     def find
-      font_names = map_name_to_valid_font_names
-      return if font_names.nil? || font_names.empty?
+      return unless @font_name
 
-      paths = font_paths.grep(/#{font_names.join("|")}/i)
+      filenames = fonts_filenames
+      return if filenames.empty?
+
+      paths = font_paths.select do |path|
+        filenames.any? { |f| File.basename(path).casecmp?(f) }
+      end
+
       paths.empty? ? nil : paths
     end
 
     private
 
-    attr_reader :font
-
-    def map_name_to_valid_font_names
-      fonts = Formula.find_fonts(font)
-      return unless fonts
-
+    def fonts_filenames
       fonts.map { |font| font.styles.map(&:font) }.flatten
+    end
+
+    def fonts
+      by_key || by_name || []
+    end
+
+    def by_key
+      _key, formula = formulas.detect do |key, _value|
+        key.to_s.casecmp?(@font_name)
+      end
+
+      return unless formula
+
+      formula.fonts
+    end
+
+    def by_name
+      _key, formula = formulas.detect do |_key, value|
+        value.fonts.map(&:name).map(&:downcase).include?(@font_name.downcase)
+      end
+
+      return unless formula
+
+      formula.fonts.select do |font|
+        font.name.casecmp?(@font_name)
+      end
+    end
+
+    def formulas
+      @formulas ||= Fontist::Registry.instance.formulas.to_h
     end
 
     def font_paths
       Dir.glob(Fontist.fonts_path.join("**"))
+    end
+
+    def check_and_register_font_formulas
+      $check_and_register_font_formulas ||= Fontist::Formulas.register_formulas
     end
   end
 end

--- a/lib/fontist/formula.rb
+++ b/lib/fontist/formula.rb
@@ -28,7 +28,8 @@ module Fontist
 
     def find_fonts
       formulas = [find_formula].flatten
-      match_fonts_by_name(formulas) unless formulas.empty?
+      fonts = take_fonts(formulas)
+      fonts.empty? ? nil : fonts
     end
 
     private
@@ -36,21 +37,15 @@ module Fontist
     attr_reader :font_name
 
     def find_formula
-      find_by_font_name || find_by_key || find_by_font || []
+      find_by_key || find_by_font_name || find_by_font || []
     end
 
     def formulas
       @formulas ||= all.to_h
     end
 
-    def match_fonts_by_name(formulas)
-      matched_fonts = formulas.map do |formula|
-        formula.fonts.select do |font|
-          font.name.downcase == font_name.downcase
-        end
-      end.flatten
-
-      matched_fonts.empty? ? nil : matched_fonts
+    def take_fonts(formulas)
+      formulas.map(&:fonts).flatten
     end
 
     def find_by_key

--- a/lib/fontist/formula_template.rb
+++ b/lib/fontist/formula_template.rb
@@ -64,6 +64,14 @@ module Fontist
           formula.fonts.each do |font|
             match_fonts(resource, font.name)
           end
+
+          if formula.font_collections
+            formula.font_collections.each do |collection|
+              collection.fonts.each do |font|
+                match_fonts(resource, font.name)
+              end
+            end
+          end
         end
 
         klass.define_method :install do

--- a/lib/fontist/system_font.rb
+++ b/lib/fontist/system_font.rb
@@ -10,7 +10,7 @@ module Fontist
     end
 
     def find
-      paths = font_paths.grep(/#{font}/i)
+      paths = grep_font_paths(font)
       paths = lookup_using_font_name || []  if paths.empty?
 
       paths.empty? ? nil : paths
@@ -27,6 +27,13 @@ module Fontist
 
         passwd ? path.gsub("{username}", passwd.name) : path
       end
+    end
+
+    def grep_font_paths(font)
+      paths = font_paths.map { |path| [File.basename(path), path] }.to_h
+      files = paths.keys
+      matched = files.grep(/#{font}/i)
+      paths.values_at(*matched).compact
     end
 
     def font_paths
@@ -71,7 +78,7 @@ module Fontist
     end
 
     def system_path_file
-      File.open(Fontist.lib_path.join("fontist", "system.yml"))
+      File.open(Fontist.system_file_path)
     end
 
     def default_sources

--- a/spec/fixtures/system.yml
+++ b/spec/fixtures/system.yml
@@ -1,0 +1,12 @@
+system:
+  linux:
+    paths: []
+
+  windows:
+    paths: []
+
+  macos:
+    paths: []
+
+  unix:
+    paths: []

--- a/spec/fontist/cli_spec.rb
+++ b/spec/fontist/cli_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Fontist::CLI do
 
           expect(Fontist.ui).to receive(:success)
             .with(include("ExtraLight"))
-          status = described_class.start(["status", "source hans sans"])
+          status = described_class.start(["status", "source han sans"])
           expect(status).to be 0
         end
       end

--- a/spec/fontist/formula_spec.rb
+++ b/spec/fontist/formula_spec.rb
@@ -40,11 +40,12 @@ RSpec.describe Fontist::Formula do
   describe ".find_fonts" do
     it "returns the exact font font names" do
       name = "Calibri"
-      font = Fontist::Formula.find_fonts(name).last
+      fonts = Fontist::Formula.find_fonts(name)
+      filenames = fonts.map(&:styles).flatten.map(&:font)
 
-      expect(font.styles.map(&:font)).to include("CALIBRI.TTF")
-      expect(font.styles.map(&:font)).to include("CALIBRIB.TTF")
-      expect(font.styles.map(&:font)).to include("CALIBRII.TTF")
+      expect(filenames).to include("CALIBRI.TTF")
+      expect(filenames).to include("CALIBRIB.TTF")
+      expect(filenames).to include("CALIBRII.TTF")
     end
 
     it "returns nil if invalid name provided" do

--- a/spec/fontist/formulas/cleartype_font_spec.rb
+++ b/spec/fontist/formulas/cleartype_font_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Fontist::Formulas::ClearTypeFont do
           name, confirmation: confirmation
         )
 
-        expect(paths.first).to include("fonts/#{name.upcase}.TTC")
+        expect(paths).to include(include("fonts/#{name.upcase}.TTC"))
       end
     end
 

--- a/spec/fontist/formulas/source_font_spec.rb
+++ b/spec/fontist/formulas/source_font_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Fontist::Formulas::SourceFont do
     it "builds the data dictionary" do
       formula = Fontist::Formulas::SourceFont.instance
 
-      expect(formula.fonts.count).to eq(33)
-      expect(formula.fonts.first[:name]).to eq("Source Hans Sans")
+      expect(formula.fonts.count).to eq(38)
+      expect(formula.fonts.first[:name]).to eq("Source Han Sans")
     end
   end
 

--- a/spec/fontist/formulas/stix_fonts_spec.rb
+++ b/spec/fontist/formulas/stix_fonts_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Fontist::Formulas::StixFont do
         )
 
         expect(Fontist::Font.find(name)).not_to be_empty
-        expect(paths.first).to include("fonts/STIX2Math.otf")
+        expect(paths).to include(include("fonts/STIX2Math.otf"))
       end
     end
   end

--- a/spec/fontist/system_font_spec.rb
+++ b/spec/fontist/system_font_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Fontist::SystemFont do
   describe ".find" do
     context "with a valid existing font" do
       it "returns the complete font path" do
+        stub_system_fonts
+
         name = "DejaVuSerif.ttf"
         dejavu_ttf = Fontist::SystemFont.find(name, sources: [font_sources])
 

--- a/spec/support/fontist_helper.rb
+++ b/spec/support/fontist_helper.rb
@@ -14,7 +14,9 @@ module Fontist
     end
 
     def stub_system_fonts
-      allow(Fontist::SystemFont).to receive(:find).and_return(nil)
+      allow(Fontist).to receive(:system_file_path).and_return(
+        Fontist.root_path.join("spec", "fixtures", "system.yml")
+      )
     end
 
     def stub_system_font_finder_to_fixture(name)


### PR DESCRIPTION
- Fix installation of "Source Hans Sans" not returning the *.ttc paths
- Fix installation of "Source" skipping and returning the wrong system fonts
- Prefer exact match by key over partial match in fonts: for "Source" return Source formula, instead of Source Code Pro formula
- Fix not working removal of whole formula
- Correct name for Source Han Sans (see https://github.com/fontist/formulas/pull/32)