### PR TITLE
GHA release fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
-          architecture: 'x64'
 
       - run: bundle config set path 'vendor/bundle'
 
@@ -37,4 +36,3 @@ jobs:
           chmod 0600 ~/.gem/credentials
           git status
           gem release
-

--- a/README.md
+++ b/README.md
@@ -434,6 +434,22 @@ git commit -m "Google Fonts update"
 git push
 ```
 
+### Releasing
+
+Releasing is done automatically with GitHub Action. Just bump and tag with `gem-release`.
+
+For a patch release (0.0.x) use:
+
+```sh
+gem bump --version patch --tag --push
+```
+
+For a minor release (0.x.0) use:
+
+```sh
+gem bump --version minor --tag --push
+```
+
 ## Contributing
 
 First, thank you for contributing! We love pull requests from everyone. By

--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "extract_ttc", "~> 0.1"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "bundler", "~> 2.0"
+  spec.add_development_dependency "gem-release"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "0.75.0"


### PR DESCRIPTION
Seems it uses a different version of bundler:

```
Run bundle install --jobs 4 --retry 3
Fetching gem metadata from https://rubygems.org/.........
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 2.0)

  Current Bundler version:
    bundler (1.17.2)
This Gemfile requires a different version of Bundler.
Perhaps you need to update Bundler by running `gem install bundler`?

Could not find gem 'bundler (~> 2.0)' in any of the relevant sources:
  the local ruby installation
```

https://github.com/fontist/fontist/runs/1585158834?check_suite_focus=true