### PR TITLE
metanorma/metanorma#202 respect HTTP[S]|SOCKS_PROXY env vars during git clone

### DIFF
--- a/lib/fontist/repo.rb
+++ b/lib/fontist/repo.rb
@@ -1,4 +1,5 @@
 require "git"
+require "fontist/utils/git"
 
 module Fontist
   class Repo
@@ -48,7 +49,7 @@ module Fontist
         if Dir.exist?(path)
           Git.open(path).pull
         else
-          Git.clone(url, path, depth: 1)
+          Utils::Git.clone(url, path, depth: 1)
         end
       end
 

--- a/lib/fontist/update.rb
+++ b/lib/fontist/update.rb
@@ -20,9 +20,9 @@ module Fontist
       if Dir.exist?(Fontist.formulas_repo_path)
         Git.open(Fontist.formulas_repo_path).pull
       else
-        Git.clone(Fontist.formulas_repo_url,
-                  Fontist.formulas_repo_path,
-                  depth: 1)
+        Utils::Git.clone(Fontist.formulas_repo_url,
+                         Fontist.formulas_repo_path,
+                         depth: 1)
       end
     end
 

--- a/lib/fontist/utils/git.rb
+++ b/lib/fontist/utils/git.rb
@@ -1,0 +1,28 @@
+require "git"
+
+module Fontist
+  module Utils
+    class Git
+      def self.clone(url, path, opts)
+        http_proxy = ENV["SOCKS_PROXY"] || ENV["HTTP_PROXY"]
+        https_proxy = ENV["SOCKS_PROXY"] || ENV["HTTPS_PROXY"]
+        if http_proxy || https_proxy
+          clone_with_proxy(http_proxy, https_proxy, url, path, opts)
+        else
+          ::Git.clone(url, path, opts)
+        end
+      end
+
+      def self.clone_with_proxy(http_proxy, https_proxy, url, path, _opts)
+        git = Git.init(path.to_s)
+        # NOTE what if user move out of proxy?
+        git.config("http.proxy", http_proxy) if http_proxy
+        git.config("https.proxy", https_proxy) if https_proxy
+        git.add_remote("origin", url)
+        git.fetch
+        git.checkout("master") # FIXME after https://github.com/ruby-git/ruby-git/pull/532
+        path
+      end
+    end
+  end
+end


### PR DESCRIPTION
 - metanorma/metanorma#202

## Open questions

 - Should we handle a case git repos which were cloned with proxy and then metanorma executed without proxy?

## Related PRs:
 - https://github.com/metanorma/metanorma-cli/pull/247