### PR TITLE
Logging levels

### DIFF
--- a/lib/fontist.rb
+++ b/lib/fontist.rb
@@ -119,11 +119,7 @@ module Fontist
     @preferred_family = bool
   end
 
-  def self.debug?
-    @debug || false
-  end
-
-  def self.debug=(bool)
-    @debug = bool
+  def self.log_level=(level)
+    Fontist.ui.level = level
   end
 end

--- a/lib/fontist/cli.rb
+++ b/lib/fontist/cli.rb
@@ -1,10 +1,13 @@
 require "thor"
+require "fontist/cli/class_options"
 require "fontist/repo_cli"
 require "fontist/import_cli"
 require "fontist/google_cli"
 
 module Fontist
   class CLI < Thor
+    include ClassOptions
+
     STATUS_SUCCESS = 0
     STATUS_UNKNOWN_ERROR = 1
     STATUS_NON_SUPPORTED_FONT_ERROR = 2
@@ -48,6 +51,13 @@ module Fontist
     class_option :preferred_family,
                  type: :boolean,
                  desc: "Use Preferred Family when available"
+
+    class_option :quiet,
+                 aliases: :q,
+                 type: :boolean,
+                 desc: "Hide all messages"
+
+    class_option :formulas_path, type: :string, desc: "Path to formulas"
 
     desc "install FONT", "Install font"
     option :force, type: :boolean, aliases: :f,
@@ -134,8 +144,12 @@ module Fontist
     end
 
     desc "manifest-install MANIFEST", "Install fonts from MANIFEST (yaml)"
-    option :accept_all_licenses, type: :boolean, aliases: "--confirm-license", desc: "Accept all license agreements"
-    option :hide_licenses, type: :boolean, desc: "Hide license texts"
+    option :accept_all_licenses, type: :boolean,
+                                 aliases: ["--confirm-license", :a],
+                                 desc: "Accept all license agreements"
+    option :hide_licenses, type: :boolean,
+                           aliases: :h,
+                           desc: "Hide license texts"
     def manifest_install(manifest)
       handle_class_options(options)
       paths = Fontist::Manifest::Install.from_file(
@@ -195,10 +209,6 @@ module Fontist
     subcommand "google", Fontist::GoogleCLI
 
     private
-
-    def handle_class_options(options)
-      Fontist.preferred_family = options[:preferred_family]
-    end
 
     def success
       STATUS_SUCCESS

--- a/lib/fontist/cli/class_options.rb
+++ b/lib/fontist/cli/class_options.rb
@@ -1,0 +1,14 @@
+module Fontist
+  class CLI < Thor
+    module ClassOptions
+      def handle_class_options(options)
+        Fontist.preferred_family = options[:preferred_family]
+        Fontist.log_level = options[:quiet] ? :fatal : :info
+
+        if options[:formulas_path]
+          Fontist.formulas_path = Pathname.new(options[:formulas_path])
+        end
+      end
+    end
+  end
+end

--- a/lib/fontist/google_cli.rb
+++ b/lib/fontist/google_cli.rb
@@ -1,6 +1,6 @@
 module Fontist
   class GoogleCLI < Thor
-    class_option :formulas_path, type: :string, desc: "Path to formulas"
+    include CLI::ClassOptions
 
     desc "check", "Check Google fonts for updates"
     def check
@@ -16,14 +16,6 @@ module Fontist
       require "fontist/import/google_import"
       Fontist::Import::GoogleImport.new.call
       CLI::STATUS_SUCCESS
-    end
-
-    private
-
-    def handle_class_options(options)
-      if options[:formulas_path]
-        Fontist.formulas_path = Pathname.new(options[:formulas_path])
-      end
     end
   end
 end

--- a/lib/fontist/import/helpers/system_helper.rb
+++ b/lib/fontist/import/helpers/system_helper.rb
@@ -4,7 +4,7 @@ module Fontist
       module SystemHelper
         class << self
           def run(command)
-            Fontist.ui.say("Run `#{command}`") if Fontist.debug?
+            Fontist.ui.debug("Run `#{command}`")
 
             result = `#{command}`
             unless $CHILD_STATUS.to_i.zero?

--- a/lib/fontist/import_cli.rb
+++ b/lib/fontist/import_cli.rb
@@ -1,16 +1,14 @@
 module Fontist
   class ImportCLI < Thor
+    include CLI::ClassOptions
+
     desc "macos", "Create formula for on-demand macOS fonts"
     option :name, desc: "Example: Big Sur", required: true
     option :fonts_link,
            desc: "A link to a list of available fonts in a current OS",
            required: true
-    option :formulas_path, type: :string, desc: "Path to formulas"
     def macos
-      if options[:formulas_path]
-        Fontist.formulas_path = Pathname.new(options[:formulas_path])
-      end
-
+      handle_class_options(options)
       require_relative "import/macos"
       Import::Macos.new(options).call
       CLI::STATUS_SUCCESS

--- a/lib/fontist/repo_cli.rb
+++ b/lib/fontist/repo_cli.rb
@@ -1,9 +1,12 @@
 module Fontist
   class RepoCLI < Thor
+    include CLI::ClassOptions
+
     desc "setup NAME URL",
          "Setup a custom fontist repo named NAME for the repository at URL " \
          "and fetches its formulas"
     def setup(name, url)
+      handle_class_options(options)
       Repo.setup(name, url)
       Fontist.ui.success(
         "Fontist repo '#{name}' from '#{url}' has been successfully set up.",
@@ -13,6 +16,7 @@ module Fontist
 
     desc "update NAME", "Update formulas in a fontist repo named NAME"
     def update(name)
+      handle_class_options(options)
       Repo.update(name)
       Fontist.ui.success(
         "Fontist repo '#{name}' has been successfully updated.",
@@ -24,6 +28,7 @@ module Fontist
 
     desc "remove NAME", "Remove fontist repo named NAME"
     def remove(name)
+      handle_class_options(options)
       Repo.remove(name)
       Fontist.ui.success(
         "Fontist repo '#{name}' has been successfully removed.",
@@ -35,6 +40,7 @@ module Fontist
 
     desc "list", "List fontist repos"
     def list
+      handle_class_options(options)
       Repo.list.each do |name|
         Fontist.ui.say(name)
       end

--- a/lib/fontist/utils/ui.rb
+++ b/lib/fontist/utils/ui.rb
@@ -3,16 +3,36 @@ require "thor"
 module Fontist
   module Utils
     class UI < Thor
+      ALL_LEVELS = %i[debug info warn error fatal unknown].freeze
+
+      def self.level=(level)
+        unless ALL_LEVELS.include?(level)
+          raise Errors::GeneralError,
+                "Unknown log level: #{level.inspect}. " \
+                "Supported levels are #{ALL_LEVELS.map(&:inspect).join(', ')}."
+        end
+
+        @level = level
+      end
+
+      def self.level
+        @level || default_level
+      end
+
+      def self.default_level
+        :fatal
+      end
+
       def self.success(message)
-        new.say(message, :green)
+        new.say(message, :green) if log_levels.include?(:info)
       end
 
       def self.error(message)
-        new.say(message, :red)
+        new.say(message, :red) if log_levels.include?(:warn)
       end
 
       def self.say(message)
-        new.say(message)
+        new.say(message) if log_levels.include?(:info)
       end
 
       def self.ask(message, options = {})
@@ -20,7 +40,16 @@ module Fontist
       end
 
       def self.print(message)
-        super
+        super if log_levels.include?(:info)
+      end
+
+      def self.debug(message)
+        new.say(message) if log_levels.include?(:debug)
+      end
+
+      def self.log_levels
+        @log_levels ||= {}
+        @log_levels[@level] ||= ALL_LEVELS.drop_while { |l| l != level }
       end
     end
   end

--- a/spec/fontist/utils/ui_spec.rb
+++ b/spec/fontist/utils/ui_spec.rb
@@ -1,0 +1,76 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Utils::UI do
+  before do
+    allow(Fontist.ui).to receive(:say).and_call_original
+    allow(Fontist.ui).to receive(:success).and_call_original
+    allow(Fontist.ui).to receive(:error).and_call_original
+    allow(Fontist.ui).to receive(:print).and_call_original
+  end
+
+  context "by default" do
+    around do |example|
+      Fontist.ui.level.tap do |level|
+        Fontist.ui.level = Fontist.ui.default_level
+        example.run
+        Fontist.ui.level = level
+      end
+    end
+
+    it "prints nothing" do
+      expect { Fontist.ui.success("msg") }.to output("").to_stdout
+      expect { Fontist.ui.error("msg") }.to output("").to_stdout
+      expect { Fontist.ui.say("msg") }.to output("").to_stdout
+      expect { Fontist.ui.print("msg") }.to output("").to_stdout
+      expect { Fontist.ui.debug("msg") }.to output("").to_stdout
+    end
+  end
+
+  context "warn level" do
+    around do |example|
+      Fontist.ui.level = :warn
+      example.run
+      Fontist.ui.level = Fontist.ui.default_level
+    end
+
+    it "prints only error" do
+      expect { Fontist.ui.success("msg") }.to output("").to_stdout
+      expect { Fontist.ui.error("msg") }.to output("msg\n").to_stdout
+      expect { Fontist.ui.say("msg") }.to output("").to_stdout
+      expect { Fontist.ui.print("msg") }.to output("").to_stdout
+      expect { Fontist.ui.debug("msg") }.to output("").to_stdout
+    end
+  end
+
+  context "info level" do
+    around do |example|
+      Fontist.ui.level = :info
+      example.run
+      Fontist.ui.level = Fontist.ui.default_level
+    end
+
+    it "prints everything except debug" do
+      expect { Fontist.ui.success("msg") }.to output("msg\n").to_stdout
+      expect { Fontist.ui.error("msg") }.to output("msg\n").to_stdout
+      expect { Fontist.ui.say("msg") }.to output("msg\n").to_stdout
+      expect { Fontist.ui.print("msg") }.to output("msg").to_stdout
+      expect { Fontist.ui.debug("msg") }.to output("").to_stdout
+    end
+  end
+
+  context "debug level" do
+    around do |example|
+      Fontist.ui.level = :debug
+      example.run
+      Fontist.ui.level = Fontist.ui.default_level
+    end
+
+    it "prints everything" do
+      expect { Fontist.ui.success("msg") }.to output("msg\n").to_stdout
+      expect { Fontist.ui.error("msg") }.to output("msg\n").to_stdout
+      expect { Fontist.ui.say("msg") }.to output("msg\n").to_stdout
+      expect { Fontist.ui.print("msg") }.to output("msg").to_stdout
+      expect { Fontist.ui.debug("msg") }.to output("msg\n").to_stdout
+    end
+  end
+end


### PR DESCRIPTION
This PR turns off all logging for Ruby calls, but keeps for CLI.

Also adds the `--quiet` option to disable logs even in CLI.

Closes #276 
