### PR TITLE
 allow 'override' font metadata to install/query fonts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -333,7 +333,7 @@ FONTIST_PATH=~/.fontist_new fontist update
 ----
 
 
-== Usage of the Fontist Ruby library
+== Using the Ruby library
 
 === `Fontist::Font`
 
@@ -567,13 +567,23 @@ Fontist::Fontconfig.remove              # disable detection
 Fontist::Fontconfig.remove(force: true) # do not fail if no config exists
 ----
 
-== Installing macOS-specific add-on fonts
 
-The purpose of Fontist allowing macOS-specific add-on fonts is to allow CI jobs
-on macOS environments to use these specially licensed fonts that are not
-available on other platforms.
+== Platform-specific features
 
-The "Canela" font is a commercial font that comes free with macOS.
+=== macOS-specific add-on fonts
+
+Newer versions of macOS provide on-demand installations of a wide range of
+licensed fonts. These macOS-specific add-on fonts can be installed via Fontist.
+
+A typical use for installing macOS add-on fonts is to allow CI jobs on
+macOS environments to use these specially-licensed fonts not available on other
+platforms.
+
+This blog post describes how this works:
+
+* https://www.fontist.org/blog/2022-02-11-macos-fonts/[Fontist blog: Installing macOS-specific add-on fonts]
+
+For example, the "Canela" font is a commercial font that comes free with macOS.
 
 Run this command to install Canela on macOS.
 
@@ -582,10 +592,20 @@ Run this command to install Canela on macOS.
 $ fontist install Canela
 ----
 
-WARNING: Fontist does not allow installing macOS-specific fonts on non-macOS
-platforms due to font licensing of those fonts.
+The full list of available fonts on various macOS versions can be found on the
+Apple Support site:
 
-== Using Fontist with proxy servers
+* https://support.apple.com/en-us/HT213266[Fonts in macOS 13 Ventura]
+* https://support.apple.com/en-us/HT212587[Fonts in macOS 12 Monteray]
+* https://support.apple.com/en-in/HT211240[Fonts in macOS 11 Big Sur]
+
+WARNING: Fontist does not allow installing macOS-specific fonts on non-macOS
+platforms due to font license restrictions of those fonts.
+
+
+== Advanced usage
+
+=== Using proxy servers
 
 Fontist uses Git internally for fetching formulas and fonts.
 
@@ -642,33 +662,36 @@ https://github.com/evantoli[evantoli]).
 
 
 
-== Authoring Fontist formulas
+== Custom Fontist repositories
 
-=== Private Fontist formulas and font repositories
-
-Fontist supports installing private fonts via private Fontist repositories.
+=== General
 
 A Fontist repository is a Git repo which contains YAML Formula files.
-Formulas can be created manually
+Fontist Formulas can be created manually within a Fontist repository
 (see https://github.com/fontist/formulas/tree/master/Formulas[examples]),
-or <<create-formula,auto-generated from an archive>>.
+or <<create-formula,auto-generated from a font archive>>.
 
-A repository can be either a HTTPS or SSH Git repo. In case of SSH, a
-corresponding SSH key should be setup with `ssh-agent` in order to access this
-private repository.
+A Fontist repository can be accessed either through HTTPS or SSH. In case of
+SSH, a corresponding SSH key should be setup with `ssh-agent` in order to access
+this custom repository.
 
-The `fontist repo setup` command fetches a repository's formulas, and saves the
-repository's name and URL for later use.
+=== Registering a Fontist repository
 
-Internally, all repositories are stored at
-`~/.fontist/formulas/Formulas/private`.
+The `fontist repo setup` command fetches a custom repository's formulas, and
+stores the repository's name and URL for later use.
+
+The `fontist repo setup` command uses the following syntax.
 
 [source,sh]
 ----
 fontist repo setup NAME URL
 ----
 
-E.g.
+Internally, all custom Fontist repository information is stored at
+`~/.fontist/formulas/Formulas/private`.
+
+For example, given a Fontist repository called "acme" accessible via a
+URL or an SSH address:
 
 [source,sh]
 ----
@@ -677,40 +700,63 @@ fontist repo setup acme https://example.com/acme/formulas.git
 fontist repo setup acme git@example.com:acme/formulas.git
 ----
 
-Then you can just install fonts from this repo:
+
+=== Listing custom Fontist repositories
 
 [source,sh]
 ----
-fontist install "private font"
+fontist repo list
 ----
 
-If the private Fontist formula repository is updated, you can fetch the updates
-with the `repo update` command:
+
+=== Installing fonts from a Fontist repository
+
+Once the custom Fontist repository is setup, one can install fonts from the
+repo through its formulas:
+
+[source,sh]
+----
+fontist install "custom font"
+----
+
+
+=== Updating a registered Fontist repository
+
+If the custom Fontist formula repository is updated, the `repo update` command
+is used to pull the newest changes:
+
+[source,sh]
+----
+fontist repo update NAME
+----
+
+For example, given a Fontist repository called "acme", the following command
+is used.
 
 [source,sh]
 ----
 fontist repo update acme
 ----
 
-If there is a need to avoid using private formulas, the repo can be removed
-with:
+
+=== Removing a registered Fontist repository
+
+If there is a need to remove a registered Fontist repository, the repo can be
+removed with:
 
 [source,sh]
 ----
 fontist repo remove acme
 ----
 
-[[create-formula]]
-=== Auto-generate a Fontist formula from a font archive
 
-A formula could be generated from a fonts archive. Just specify a URL to the
-archive:
+=== Private access
 
-[source,sh]
-----
-fontist create-formula https://www.latofonts.com/download/lato2ofl-zip/
-cp lato.yml ~/.fontist/formulas/Formulas/
-----
+Custom Fontist formulas and Fontist repositories can be made private to require
+authentication.
+
+For HTTPS and SSH Git Fontist repositories
+
 
 === Authentication for private formulas or private formula repositories
 
@@ -730,11 +776,57 @@ resources:
         Authorization: token ghp_1234567890abcdefghi
 ----
 
-A token can be obtained on the
-https://github.com/settings/tokens[GitHub Settings > Tokens page].
+If the Fontist formula repository is a GitHub repo, a token can be obtained on
+the https://github.com/settings/tokens[GitHub Settings > Tokens page].
 This token should have at least the `repo` scope for access to these assets.
 
 
+
+[[create-formula]]
+=== Create Fontist formulas
+
+==== General
+
+Fontist formulas can be easily hand-crafted in YAML. However, the
+auto-generation method is recommended for data accuracy and convenience.
+
+
+==== Auto-generate a Fontist formula from a font archive
+
+A formula could be generated from a fonts archive.
+
+The `fontist create-formula` command allows detecting all font files from a
+font archive in a multitude of formats (those supported by
+https://github.com/fontist/excavate[Excavate], including zip, 7z, gzip, tar,
+cab, exe).
+
+The `fontist create-formula` command supports archives located at remote URLs or
+local file paths.
+
+For file paths, specify the file path as argument:
+
+[source,sh]
+----
+wget https://www.latofonts.com/download/lato2ofl-zip/
+fontist create-formula lato.zip
+----
+
+For URLs, simply specify the URL as the argument:
+
+[source,sh]
+----
+fontist create-formula https://www.latofonts.com/download/lato2ofl-zip/
+# > file created at lato.yml because the file downloaded is lato.zip
+----
+
+To test out the created formula, one may copy the formula into the user's
+private formula repository location.
+
+[source,sh]
+----
+fontist create-formula https://www.latofonts.com/download/lato2ofl-zip/
+cp lato.yml ~/.fontist/formulas/Formulas/
+----
 
 
 ==== Overriding font metadata in Fontist formulas

--- a/README.adoc
+++ b/README.adoc
@@ -734,14 +734,55 @@ A token can be obtained on the
 https://github.com/settings/tokens[GitHub Settings > Tokens page].
 This token should have at least the `repo` scope for access to these assets.
 
-=== Override font's metadata to simplify
 
-For some fonts, we are faced with issues in font metadata. For example: "Frutiger" fonts used numbers to represent every font -- this means that "Frutiger Light", "Frutiger LightItalic", "Frutiger LightBold" are all considered "different font families", which is most certainly wrong.
 
-Here is how the `override` property can help:
+
+==== Overriding font metadata in Fontist formulas
+
+The `fontist create-formula` command creates font formulas using information
+embedded in the OTF metadata section.
+
+However, some fonts (such as older fonts) often contain inconsistent or
+imperfect metadata information. Some fonts for example applies different OTF
+`Family` values for different font styles. This will result in all font styles
+not being registered in the same Family.
+
+Fontist formula authors can rectify this situation by using the `override:` key,
+which allows the formula to override metadata information obtained from the font
+metadata.
+
+NOTE: The `override` key does not cause any change in the font files, it is only
+for updating information used by Fontist internally.
+
+The `override` key exists under the definition of individual font styles:
 
 [source,yaml]
----
+----
+resources:
+  ...
+fonts:
+- name: Original font name
+  styles:
+    - family_name: Original family name
+      type: Original style
+      override:
+        family_name: Overridden family name
+        type: Overridden style
+        preferred_family_name: Overridden preferred family name
+----
+
+For example, the "Frutiger" fonts published by Adobe in 1994 use numbers to
+represent the individual font styles, and have those names embedded in the OTF
+`Family` field, such as "Frutiger 45 Light". These fonts also do not use the OTF
+`Preferred Family` field, which is a more recent addition to OTF, due to their
+age.
+
+Here is how the `override` property can enforce all relevant styles to be
+registered under the same family name (by overriding the `preferred_family_name`
+value):
+
+[source,yaml]
+----
 ...
 resources:
   ...
@@ -757,9 +798,14 @@ fonts:
   - ...
 ----
 
-For the fragment above `fontist` will generate correct indexes and will allow easy install of all `Frutiger` fonts with a single command: `fontist install "Frutiger" --preferred-family`
+This fragment above will allow Fontist to generate correct indexes and allow
+installation of all `Frutiger` fonts with a single command:
 
-Fontist will not overwrite `overridde`n properties in actual `otf` files
+[source,sh]
+----
+$ fontist install "Frutiger" --preferred-family
+----
+
 
 === Upgrading Fontist
 

--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,8 @@ image:https://img.shields.io/github/issues-pr-raw/fontist/fontist.svg["Pull Requ
 
 A simple library to find and download fonts for Windows, Linux and Mac.
 
+:toc:
+
 == Installation
 
 Install it directly as:
@@ -732,6 +734,32 @@ A token can be obtained on the
 https://github.com/settings/tokens[GitHub Settings > Tokens page].
 This token should have at least the `repo` scope for access to these assets.
 
+=== Override font's metadata to simplify
+
+For some fonts, we are faced with issues in font metadata. For example: "Frutiger" fonts used numbers to represent every font -- this means that "Frutiger Light", "Frutiger LightItalic", "Frutiger LightBold" are all considered "different font families", which is most certainly wrong.
+
+Here is how the `override` property can help:
+
+[source,yaml]
+---
+...
+resources:
+  ...
+fonts:
+- name: Frutiger 45 Light
+  styles:
+  - family_name: Frutiger 45 Light
+    type: Regular
+    full_name: Frutiger-Light
+    post_script_name: Frutiger-Light
+    override:
+      preferred_family_name: Frutiger
+  - ...
+----
+
+For the fragment above `fontist` will generate correct indexes and will allow easy install of all `Frutiger` fonts with a single command: `fontist install "Frutiger" --preferred-family`
+
+Fontist will not overwrite `overridde`n properties in actual `otf` files
 
 === Upgrading Fontist
 

--- a/lib/fontist/formula.rb
+++ b/lib/fontist/formula.rb
@@ -52,6 +52,16 @@ module Fontist
       new_from_file(path)
     end
 
+    def self.find_by_font_file(font_file)
+      key = Indexes::FilenameIndex
+        .from_yaml
+        .load_index_formulas(File.basename(font_file))
+        .map(&:name)
+        .first
+
+      find_by_key(key)
+    end
+
     def self.new_from_file(path)
       data = YAML.load_file(path)
       new(data, path)
@@ -140,6 +150,14 @@ module Fontist
 
     def digest
       @data["digest"]
+    end
+
+    def style_override(font)
+      fonts
+        .map(&:styles)
+        .flatten
+        .detect { |s| s.family_name == font }
+        &.dig(:override) || {}
     end
 
     private

--- a/lib/fontist/formula.rb
+++ b/lib/fontist/formula.rb
@@ -163,8 +163,8 @@ module Fontist
     private
 
     def key_from_path
-      escaped = Regexp.escape(Fontist.formulas_path.to_s + "/")
-      @path.sub(Regexp.new("^" + escaped), "").sub(/\.yml$/, "")
+      escaped = Regexp.escape("#{Fontist.formulas_path}/")
+      @path.sub(Regexp.new("^#{escaped}"), "").sub(/\.yml$/, "")
     end
 
     def fonts_by_family

--- a/spec/fontist/formula_spec.rb
+++ b/spec/fontist/formula_spec.rb
@@ -71,4 +71,23 @@ RSpec.describe Fontist::Formula do
       expect(formula.license_required).to be false
     end
   end
+
+  describe ".find_by_font_file" do
+    it "existing font file" do
+      font_path = examples_font_path("ariali.ttf")
+      formula = described_class.find_by_font_file(font_path)
+      expect(formula).not_to be_nil
+    end
+
+    it "missing font file" do
+      expect(described_class.find_by_font_file("NonExisting.otf")).to be_nil
+    end
+  end
+
+  describe ".style_override" do
+    it "never nil" do
+      formula = described_class.find("Calibri")
+      expect(formula.style_override("Calibri")).not_to be_nil
+    end
+  end
 end

--- a/spec/fontist/system_index_spec.rb
+++ b/spec/fontist/system_index_spec.rb
@@ -71,4 +71,50 @@ RSpec.describe Fontist::SystemIndex do
       instance.find("some font", nil)
     end
   end
+
+  context "preferred family index" do
+    let(:tmp_dir) { Fontist.temp_fontist_path }
+    let(:font_file) do
+      path = File.join(tmp_dir, "AndaleMo.TTF")
+      FileUtils.cp(examples_font_path("AndaleMo.TTF"), path)
+      path
+    end
+    let(:font_paths) { [font_file] }
+    let(:index_path) { tmp_dir / "system_index.yml" }
+    let(:formula_path) do
+      path = Fontist.formulas_path / "andale.yml"
+      FileUtils.cp(examples_formula_path("andale.yml"), path)
+      path
+    end
+
+    before do
+      patch_yml(formula_path,
+                { preferred_family_name: "Andale" },
+                "fonts", 0, "styles", 0, "override")
+    end
+
+    after do
+      index_path.delete
+    end
+
+    it "does not raise errors for preferred family" do
+      described_class.new(
+        index_path,
+        -> { font_paths },
+        Fontist::SystemIndex::PreferredFamily.new,
+      ).rebuild
+
+      expect(YAML.load_file(index_path).first[:family_name]).to eq "Andale"
+    end
+
+    it "does not raise errors for default family" do
+      described_class.new(
+        index_path,
+        -> { font_paths },
+        Fontist::SystemIndex::DefaultFamily.new,
+      ).rebuild
+
+      expect(YAML.load_file(index_path).first[:family_name]).to eq "Andale Mono"
+    end
+  end
 end

--- a/spec/support/fontist_helper.rb
+++ b/spec/support/fontist_helper.rb
@@ -220,9 +220,17 @@ module Fontist
     end
 
     def example_font_to(filename, dir)
-      example_path = File.join("spec", "examples", "fonts", filename)
+      example_path = examples_font_path(filename)
       target_path = File.join(dir, filename)
       FileUtils.cp(example_path, target_path)
+    end
+
+    def examples_font_path(filename)
+      File.join("spec", "examples", "fonts", filename)
+    end
+
+    def examples_formula_path(filename)
+      File.join("spec", "examples", "formulas", filename)
     end
 
     def no_formulas(&block)
@@ -344,6 +352,13 @@ module Fontist
       yield
 
       Fontist.send("#{option}=", original)
+    end
+
+    def patch_yml(path, data, *dig_path)
+      key = dig_path.pop
+      formula = YAML.load_file(path)
+      formula.dig(*dig_path)[key] = data
+      File.write(path, YAML.dump(formula))
     end
   end
 end


### PR DESCRIPTION
 - fontist/fontist-formulas-private#8

Related PRs:
 - https://github.com/metanorma/fontist-formulas-private/pull/10

Related issues:
 - https://github.com/metanorma/metanorma-bsi/issues/212

### Details

Now `bundle exec ruby exe/fontist install "Frutiger" --preferred-family` don't download assets each time and produce:

```
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.
Fonts found at:
- /Users/camobap/.fontist/fonts/Frutiger-Black.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-BlackCn.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-BlackItalic.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-Bold.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-BoldCn.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-Cn.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-ExtraBlackCn.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-Italic.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-Light.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-LightCn.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-LightItalic.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-Roman.otf (from private/metanorma/frutiger formula)
- /Users/camobap/.fontist/fonts/Frutiger-UltraBlack.otf (from private/metanorma/frutiger formula)
```