### PR TITLE
Check for required fontist version in formulas

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -73,6 +73,10 @@ All commands support the following global options:
 NOTE: See <<preferred-family-change>> for the differences between
 "`preferred family`" and "`default family`".
 
+`-q, --quiet`:: Print as little information as possible, mostly critical errors.
+
+`-v, --verbose`:: Set the log level to debug. It prints formulas excluded
+during installation and information for developers of fontist.
 
 === Install fonts: `fontist install`
 
@@ -124,6 +128,12 @@ for the newest version of the font among formulas with size below a limit
 
 NOTE: If styles of a font are spread among several formulas, then all
 available styles from all formulas would be installed.
+
+NOTE: Some formulas may have the `min_fontist` attribute, which defines the
+minimum version of fontist by which they can be installed. If `fontist` is of a
+older version, then the formula is avoided to use. In order to see which
+formulas were excluded from the search, the `-v, --verbose` option can be
+specified.
 
 Supported options:
 
@@ -968,6 +978,15 @@ $ fontist install --formula ms_truetype
 == Maintenance (for Fontist maintainers only!)
 
 WARNING: This section is only for Fontist maintainers.
+
+=== Formulas versioning
+
+To add a new attribute, change how formula is treated or completely replace the structure, there are 2 ways to change a formula format:
+
+1. Use the `min_fontist` attribute in a formula. It sets a requirement for fontist to install the formula only if its version is equal or more than a specified version.
+2. Use a new branch in the formulas repo, e.g. "v2", "v3", "v4", etc. After creating a new branch, it should be defined in https://github.com/fontist/fontist/blob/v1.16.0/lib/fontist.rb#L51[`Fontist.formulas_version`]
+
+NOTE: Using a new branch would require all users to re-download the entire formulas repo. Since this method has a significant overhead, the former one (`min_fontist`) should be used whenever possible.
 
 === Dynamically importing formulas from Google Fonts
 

--- a/lib/fontist/cli.rb
+++ b/lib/fontist/cli.rb
@@ -25,6 +25,7 @@ module Fontist
     STATUS_FORMULA_NOT_FOUND = 13
     STATUS_FONTCONFIG_NOT_FOUND = 14
     STATUS_FONTCONFIG_FILE_NOT_FOUND = 15
+    STATUS_FONTIST_VERSION_ERROR = 15
 
     ERROR_TO_STATUS = {
       Fontist::Errors::UnsupportedFontError => [STATUS_NON_SUPPORTED_FONT_ERROR],
@@ -50,6 +51,7 @@ module Fontist
       Fontist::Errors::FontconfigNotFoundError => [STATUS_FONTCONFIG_NOT_FOUND],
       Fontist::Errors::FontconfigFileNotFoundError =>
         [STATUS_FONTCONFIG_FILE_NOT_FOUND],
+      Fontist::Errors::FontistVersionError => [STATUS_FONTIST_VERSION_ERROR],
     }.freeze
 
     def self.exit_on_failure?

--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -18,6 +18,8 @@ module Fontist
 
     class FontIndexCorrupted < GeneralError; end
 
+    class FontistVersionError < GeneralError; end
+
     class FontNotFoundError < GeneralError; end
 
     # for backward compatibility with metanorma,

--- a/lib/fontist/formula.rb
+++ b/lib/fontist/formula.rb
@@ -120,6 +120,10 @@ module Fontist
       @data["platforms"]
     end
 
+    def min_fontist
+      @data["min_fontist"]
+    end
+
     def extract
       Helpers.parse_to_object(@data["extract"])
     end

--- a/spec/examples/formulas/tex_gyre_chorus_min_fontist_1.yml
+++ b/spec/examples/formulas/tex_gyre_chorus_min_fontist_1.yml
@@ -1,0 +1,59 @@
+---
+name: TeX Gyre Chorus
+description: TeX Gyre Chorus
+resources:
+  TeX_Gyre_Chorus.zip:
+    urls:
+    - https://github.com/brechtm/rinoh-typeface-texgyrechorus/archive/v0.1.1.zip
+    sha256: b38742b48440c66fc59b9bfc601019a398673bde8d7133520049e0571bc6b7f4
+    file_size: 64419
+fonts:
+- name: TeXGyreChorus
+  styles:
+  - family_name: TeXGyreChorus
+    type: Regular
+    preferred_family_name: TeX Gyre Chorus
+    full_name: TeXGyreChorus-MediumItalic
+    post_script_name: TeXGyreChorus-MediumItalic
+    version: 2.003;PS 2.003;hotconv 1.0.49;makeotf.lib2.0.14853
+    copyright: Copyright 2006, 2009 for TeX Gyre extensions by B. Jackowski and J.M.
+      Nowacki (on behalf of TeX users groups). This work is released under the GUST
+      Font License --  see http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt for
+      details.
+    font: texgyrechorus-mediumitalic.otf
+extract: {}
+min_fontist: "0.0.1"
+copyright: Copyright 2006, 2009 for TeX Gyre extensions by B. Jackowski and J.M. Nowacki
+  (on behalf of TeX users groups). This work is released under the GUST Font License
+  --  see http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt for details.
+open_license: |-
+  % This is a preliminary version (2006-09-30), barring acceptance from
+  % the LaTeX Project Team and other feedback, of the GUST Font License.
+  % (GUST is the Polish TeX Users Group, http://www.gust.org.pl)
+  %
+  % For the most recent version of this license see
+  % http://www.gust.org.pl/fonts/licenses/GUST-FONT-LICENSE.txt
+  % or
+  % http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt
+  %
+  % This work may be distributed and/or modified under the conditions
+  % of the LaTeX Project Public License, either version 1.3c of this
+  % license or (at your option) any later version.
+  %
+  % Please also observe the following clause:
+  % 1) it is requested, but not legally required, that derived works be
+  %    distributed only after changing the names of the fonts comprising this
+  %    work and given in an accompanying "manifest", and that the
+  %    files comprising the Work, as listed in the manifest, also be given
+  %    new names. Any exceptions to this request are also given in the
+  %    manifest.
+  %
+  %    We recommend the manifest be given in a separate file named
+  %    MANIFEST-<fontid>.txt, where <fontid> is some unique identification
+  %    of the font family. If a separate "readme" file accompanies the Work,
+  %    we recommend a name of the form README-<fontid>.txt.
+  %
+  % The latest version of the LaTeX Project Public License is in
+  % http://www.latex-project.org/lppl.txt and version 1.3c or later
+  % is part of all distributions of LaTeX version 2006/05/20 or later.
+command: create-formula https://github.com/brechtm/rinoh-typeface-texgyrechorus/archive/v0.1.1.zip

--- a/spec/examples/formulas/tex_gyre_chorus_min_fontist_and_font.yml
+++ b/spec/examples/formulas/tex_gyre_chorus_min_fontist_and_font.yml
@@ -1,0 +1,59 @@
+---
+name: TeX Gyre Chorus
+description: TeX Gyre Chorus
+resources:
+  TeX_Gyre_Chorus.zip:
+    urls:
+    - https://github.com/brechtm/rinoh-typeface-texgyrechorus/archive/v0.1.1.zip
+    sha256: b38742b48440c66fc59b9bfc601019a398673bde8d7133520049e0571bc6b7f4
+    file_size: 64419
+fonts:
+- name: TeXGyreChorus
+  styles:
+  - family_name: TeXGyreChorus
+    type: Regular
+    preferred_family_name: TeX Gyre Chorus
+    full_name: TeXGyreChorus-MediumItalic
+    post_script_name: TeXGyreChorus-MediumItalic
+    version: 10.000;PS 10.003;hotconv 1.0.49;makeotf.lib2.0.14853
+    copyright: Copyright 2006, 2009 for TeX Gyre extensions by B. Jackowski and J.M.
+      Nowacki (on behalf of TeX users groups). This work is released under the GUST
+      Font License --  see http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt for
+      details.
+    font: texgyrechorus-mediumitalic.otf
+extract: {}
+min_fontist: "1000.0.0"
+copyright: Copyright 2006, 2009 for TeX Gyre extensions by B. Jackowski and J.M. Nowacki
+  (on behalf of TeX users groups). This work is released under the GUST Font License
+  --  see http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt for details.
+open_license: |-
+  % This is a preliminary version (2006-09-30), barring acceptance from
+  % the LaTeX Project Team and other feedback, of the GUST Font License.
+  % (GUST is the Polish TeX Users Group, http://www.gust.org.pl)
+  %
+  % For the most recent version of this license see
+  % http://www.gust.org.pl/fonts/licenses/GUST-FONT-LICENSE.txt
+  % or
+  % http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt
+  %
+  % This work may be distributed and/or modified under the conditions
+  % of the LaTeX Project Public License, either version 1.3c of this
+  % license or (at your option) any later version.
+  %
+  % Please also observe the following clause:
+  % 1) it is requested, but not legally required, that derived works be
+  %    distributed only after changing the names of the fonts comprising this
+  %    work and given in an accompanying "manifest", and that the
+  %    files comprising the Work, as listed in the manifest, also be given
+  %    new names. Any exceptions to this request are also given in the
+  %    manifest.
+  %
+  %    We recommend the manifest be given in a separate file named
+  %    MANIFEST-<fontid>.txt, where <fontid> is some unique identification
+  %    of the font family. If a separate "readme" file accompanies the Work,
+  %    we recommend a name of the form README-<fontid>.txt.
+  %
+  % The latest version of the LaTeX Project Public License is in
+  % http://www.latex-project.org/lppl.txt and version 1.3c or later
+  % is part of all distributions of LaTeX version 2006/05/20 or later.
+command: create-formula https://github.com/brechtm/rinoh-typeface-texgyrechorus/archive/v0.1.1.zip

--- a/spec/fontist/cli_spec.rb
+++ b/spec/fontist/cli_spec.rb
@@ -148,6 +148,17 @@ RSpec.describe Fontist::CLI do
       end
     end
 
+    context "formula requires higher min fontist" do
+      include_context "fresh home"
+
+      before { example_formula("tex_gyre_chorus_min_fontist_and_font.yml") }
+
+      it "returns fontist-version error" do
+        status = described_class.start(["install", "texgyrechorus"])
+        expect(status).to be Fontist::CLI::STATUS_FONTIST_VERSION_ERROR
+      end
+    end
+
     context "with formula option" do
       include_context "fresh home"
 


### PR DESCRIPTION
This PR lets define a requirement in a formula for minimum fontist version. So instead of failing fontist would tell it needs an upgrade.

In continuation of https://github.com/fontist/formulas/pull/150