### PR TITLE
The limit option when importing formulas for Google Fonts

### DIFF
--- a/lib/fontist/import/google.rb
+++ b/lib/fontist/import/google.rb
@@ -1,6 +1,8 @@
 module Fontist
   module Import
     module Google
+      DEFAULT_MAX_COUNT = 100
+
       def self.metadata_name(path)
         metadata_path = File.join(path, "METADATA.pb")
         return unless File.exist?(metadata_path)

--- a/lib/fontist/import/google/new_fonts_fetcher.rb
+++ b/lib/fontist/import/google/new_fonts_fetcher.rb
@@ -9,8 +9,9 @@ module Fontist
         REPO_URL = "https://github.com/google/fonts.git".freeze
         SKIPLIST_PATH = File.expand_path("skiplist.yml", __dir__)
 
-        def initialize(logging: false)
+        def initialize(logging: false, limit: nil)
           @logging = logging
+          @limit = limit
         end
 
         def call
@@ -30,11 +31,20 @@ module Fontist
         end
 
         def fetch_new_paths
-          fetch_fonts_paths.select do |path|
-            log_font(path) do
+          new_paths = []
+
+          fetch_fonts_paths.each do |path|
+            new = log_font(path) do
               new?(path)
             end
+
+            next unless new
+
+            new_paths << path
+            return new_paths if @limit && new_paths.size >= @limit
           end
+
+          new_paths
         end
 
         def fetch_fonts_paths

--- a/lib/fontist/import/google_import.rb
+++ b/lib/fontist/import/google_import.rb
@@ -6,16 +6,21 @@ require_relative "create_formula"
 module Fontist
   module Import
     class GoogleImport
+      def initialize(options)
+        @max_count = options[:max_count] || Google::DEFAULT_MAX_COUNT
+      end
+
       def call
         fonts = new_fonts
         create_formulas(fonts)
-        rebuild_index
+        rebuild_index unless fonts.empty?
       end
 
       private
 
       def new_fonts
-        Fontist::Import::Google::NewFontsFetcher.new(logging: true).call
+        Fontist::Import::Google::NewFontsFetcher.new(logging: true,
+                                                     limit: @max_count).call
       end
 
       def create_formulas(fonts)

--- a/lib/fontist/import_cli.rb
+++ b/lib/fontist/import_cli.rb
@@ -1,12 +1,19 @@
+require_relative "import/google"
+
 module Fontist
   class ImportCLI < Thor
     include CLI::ClassOptions
 
     desc "google", "Import Google fonts"
+    option :max_count,
+           type: :numeric, aliases: :n,
+           desc: "Limit the number of formulas to import " \
+                 "(default is #{Fontist::Import::Google::DEFAULT_MAX_COUNT})."
+
     def google
       handle_class_options(options)
       require "fontist/import/google_import"
-      Fontist::Import::GoogleImport.new.call
+      Fontist::Import::GoogleImport.new(options).call
       CLI::STATUS_SUCCESS
     end
 


### PR DESCRIPTION
After that PR the import would fetch by 100 formulas per time. It's easier to debug it that way later.

See https://github.com/fontist/formulas/pull/142