### PR TITLE
gemspec: Untighten version of thor

### DIFF
--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "nokogiri", "~> 1.0"
   spec.add_runtime_dependency "mime-types", "~> 3.0"
   spec.add_runtime_dependency "sys-uname", "~> 1.2"
-  spec.add_runtime_dependency "thor", "~> 1.2.1"
+  spec.add_runtime_dependency "thor", "~> 1.2", ">= 1.2.1"
   spec.add_runtime_dependency "git", "~> 1.0"
   spec.add_runtime_dependency "ttfunk", "~> 1.6"
   spec.add_runtime_dependency "plist", "~> 3.0"


### PR DESCRIPTION
This is to ensure that `coradoc` can be installed side by side, as `coradoc` requires a feature only present since thor 1.3.0

Ref: metanorma/coradoc#128