### PR TITLE
Added support for struct in formula resource url, which was removed in fontist > 2.0

### DIFF
--- a/lib/fontist/helpers.rb
+++ b/lib/fontist/helpers.rb
@@ -1,5 +1,12 @@
 module Fontist
   module Helpers
+    def self.url_object(request)
+      return request unless request.include?("\"url\"")
+
+      obj = JSON.parse(request.gsub("=>", ":"))
+      Struct.new(:url, :headers).new(obj["url"], obj["headers"])
+    end
+
     def self.run(command)
       Fontist.ui.debug("Run `#{command}`")
 

--- a/lib/fontist/resources/archive_resource.rb
+++ b/lib/fontist/resources/archive_resource.rb
@@ -33,10 +33,11 @@ module Fontist
       end
 
       def try_download_file(request, source)
-        info_log(request)
+        url = Helpers.url_object(request)
+        info_log(url)
 
         Fontist::Utils::Downloader.download(
-          request,
+          url,
           sha: source.sha256,
           file_size: source.file_size,
           progress_bar: !@options[:no_progress],

--- a/lib/fontist/utils/downloader.rb
+++ b/lib/fontist/utils/downloader.rb
@@ -102,13 +102,15 @@ module Fontist
       # rubocop:enable Metrics/MethodLength
 
       def url
-        @file.respond_to?(:url) ? @file.url : @file
+        obj = Helpers.url_object(@file)
+        obj.respond_to?(:url) ? obj.url : obj
       end
 
       def headers
-        @file.respond_to?(:headers) &&
-          @file.headers &&
-          @file.headers.to_h.map { |k, v| [k.to_s, v] }.to_h || # rubocop:disable Style/HashTransformKeys, Metrics/LineLength
+        obj = Helpers.url_object(@file)
+        obj.respond_to?(:headers) &&
+          obj.headers &&
+          obj.headers.to_h.map { |k, v| [k.to_s, v] }.to_h || # rubocop:disable Style/HashTransformKeys, Metrics/LineLength
           {}
       end
     end


### PR DESCRIPTION
fixes #405
