### PR TITLE
feat: add randomized browser User-Agent module for all downloads

### DIFF
--- a/lib/fontist/import/sil_importer.rb
+++ b/lib/fontist/import/sil_importer.rb
@@ -272,7 +272,7 @@ module Fontist
       end
 
       def font_links
-        html = URI.parse(ROOT).open.read
+        html = URI.parse(ROOT).open("User-Agent" => Fontist::Utils::UserAgent.random_user_agent).read
         document = Nokogiri::HTML.parse(html)
         document.css("table.products div.title > a")
       end
@@ -392,7 +392,7 @@ module Fontist
       end
 
       def find_archive_url_by_page_uri(uri)
-        response = uri.open
+        response = uri.open("User-Agent" => Fontist::Utils::UserAgent.random_user_agent)
         current_url = response.base_uri
         html = response.read
         document = Nokogiri::HTML.parse(html)

--- a/lib/fontist/macos/catalog/catalog_manager.rb
+++ b/lib/fontist/macos/catalog/catalog_manager.rb
@@ -55,7 +55,7 @@ module Fontist
             Fontist.ui.say("Downloading Font#{version} catalog from #{url}...") if Fontist.ui.respond_to?(:say)
 
             URI(url).open(
-              "User-Agent" => "Fontist/#{Fontist::VERSION}",
+              "User-Agent" => Fontist::Utils::UserAgent.random_user_agent,
             ) do |response|
               File.write(catalog_file, response.read)
             end

--- a/lib/fontist/utils.rb
+++ b/lib/fontist/utils.rb
@@ -9,6 +9,7 @@ module Fontist
     autoload :Locking, "#{__dir__}/utils/locking"
     autoload :System, "#{__dir__}/utils/system"
     autoload :UI, "#{__dir__}/utils/ui"
+    autoload :UserAgent, "#{__dir__}/utils/user_agent"
 
     # Converts a glob pattern to case-insensitive by replacing each
     # alphabetic character with a character class [aA]

--- a/lib/fontist/utils/downloader.rb
+++ b/lib/fontist/utils/downloader.rb
@@ -1,10 +1,6 @@
 module Fontist
   module Utils
     class Downloader
-      DEFAULT_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " \
-                           "AppleWebKit/537.36 (KHTML, like Gecko) " \
-                           "Chrome/131.0.0.0 Safari/537.36".freeze
-
       class << self
         def download(*args)
           new(*args).download
@@ -143,7 +139,7 @@ module Fontist
           obj.headers &&
           obj.headers.to_h.to_h { |k, v| [k.to_s, v] }) || {} # rubocop:disable Style/HashTransformKeys, Metrics/LineLength
 
-        { "User-Agent" => DEFAULT_USER_AGENT }.merge(formula_headers)
+        Utils::UserAgent.browser_headers.merge(formula_headers)
       end
 
       def extract_raw_url

--- a/lib/fontist/utils/user_agent.rb
+++ b/lib/fontist/utils/user_agent.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Fontist
+  module Utils
+    module UserAgent
+      PROFILES = [
+        {
+          user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/131.0.0.0 Safari/537.36",
+          platform: '"macOS"',
+          chrome_version: "131",
+        },
+        {
+          user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/130.0.0.0 Safari/537.36",
+          platform: '"Windows"',
+          chrome_version: "130",
+        },
+        {
+          user_agent: "Mozilla/5.0 (X11; Linux x86_64) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/132.0.0.0 Safari/537.36",
+          platform: '"Linux"',
+          chrome_version: "132",
+        },
+        {
+          user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/130.0.0.0 Safari/537.36",
+          platform: '"macOS"',
+          chrome_version: "130",
+        },
+        {
+          user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " \
+                      "AppleWebKit/537.36 (KHTML, like Gecko) " \
+                      "Chrome/132.0.0.0 Safari/537.36",
+          platform: '"Windows"',
+          chrome_version: "132",
+        },
+      ].freeze
+
+      ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9," \
+               "image/avif,image/webp,image/apng,*/*;q=0.8," \
+               "application/signed-exchange;v=b3;q=0.7"
+
+      ACCEPT_LANGUAGE = "en-US,en;q=0.9"
+
+      STATIC_HEADERS = {
+        "Accept" => ACCEPT,
+        "Accept-Language" => ACCEPT_LANGUAGE,
+        "Cache-Control" => "no-cache",
+        "Pragma" => "no-cache",
+        "Sec-Ch-Ua-Mobile" => "?0",
+        "Sec-Fetch-Dest" => "document",
+        "Sec-Fetch-Mode" => "navigate",
+        "Sec-Fetch-Site" => "cross-site",
+        "Sec-Fetch-User" => "?1",
+        "Upgrade-Insecure-Requests" => "1",
+      }.freeze
+
+      class << self
+        def random_profile
+          PROFILES.sample
+        end
+
+        def browser_headers
+          profile = random_profile
+          build_headers(profile)
+        end
+
+        def random_user_agent
+          random_profile[:user_agent]
+        end
+
+        private
+
+        def build_headers(profile)
+          STATIC_HEADERS.merge(
+            "User-Agent" => profile[:user_agent],
+            "Sec-Ch-Ua" => build_sec_ch_ua(profile[:chrome_version]),
+            "Sec-Ch-Ua-Platform" => profile[:platform],
+          )
+        end
+
+        def build_sec_ch_ua(chrome_version)
+          "\"Google Chrome\";v=\"#{chrome_version}\", " \
+            "\"Chromium\";v=\"#{chrome_version}\", " \
+            "\"Not_A Brand\";v=\"24\""
+        end
+      end
+    end
+  end
+end

--- a/spec/fontist/utils/downloader_spec.rb
+++ b/spec/fontist/utils/downloader_spec.rb
@@ -117,6 +117,22 @@ RSpec.describe Fontist::Utils::Downloader do
         end
       end
     end
+
+    context "browser headers" do
+      it "sends browser-like headers with the download" do
+        avoid_cache(sample_file[:file]) do
+          expect(Down).to receive(:download).and_wrap_original do |m, *args, **kwargs|
+            headers = kwargs[:headers]
+            expect(headers["User-Agent"]).to start_with("Mozilla/5.0")
+            expect(headers).to have_key("Sec-Ch-Ua")
+            expect(headers).to have_key("Sec-Fetch-Dest")
+            m.call(*args, **kwargs)
+          end
+
+          described_class.download(sample_file[:file])
+        end
+      end
+    end
   end
 
   def sample_file

--- a/spec/fontist/utils/user_agent_spec.rb
+++ b/spec/fontist/utils/user_agent_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+
+RSpec.describe Fontist::Utils::UserAgent do
+  describe ".random_profile" do
+    it "returns a hash with required keys" do
+      profile = described_class.random_profile
+      expect(profile).to include(:user_agent, :platform, :chrome_version)
+    end
+
+    it "returns a profile from the pool" do
+      profile = described_class.random_profile
+      expect(described_class::PROFILES).to include(profile)
+    end
+  end
+
+  describe ".random_user_agent" do
+    it "returns a Chrome-like string" do
+      ua = described_class.random_user_agent
+      expect(ua).to be_a(String)
+      expect(ua).to start_with("Mozilla/5.0")
+      expect(ua).to include("Chrome")
+      expect(ua).to include("AppleWebKit/537.36")
+      expect(ua).to include("Safari/537.36")
+    end
+  end
+
+  describe ".browser_headers" do
+    subject(:headers) { described_class.browser_headers }
+
+    it "returns a Hash with string keys and values" do
+      expect(headers).to be_a(Hash)
+      expect(headers.keys).to all(be_a(String))
+      expect(headers.values).to all(be_a(String))
+    end
+
+    %w[
+      User-Agent Accept Accept-Language Cache-Control Pragma
+      Sec-Ch-Ua Sec-Ch-Ua-Mobile Sec-Ch-Ua-Platform
+      Sec-Fetch-Dest Sec-Fetch-Mode Sec-Fetch-Site Sec-Fetch-User
+      Upgrade-Insecure-Requests
+    ].each do |key|
+      it "includes the #{key} header" do
+        expect(headers).to have_key(key)
+      end
+    end
+
+    it "has a self-consistent User-Agent and Sec-Ch-Ua-Platform" do
+      headers = described_class.browser_headers
+      ua = headers["User-Agent"]
+      platform = headers["Sec-Ch-Ua-Platform"]
+
+      if ua.include?("Macintosh")
+        expect(platform).to eq('"macOS"')
+      elsif ua.include?("Windows")
+        expect(platform).to eq('"Windows"')
+      elsif ua.include?("Linux")
+        expect(platform).to eq('"Linux"')
+      end
+    end
+
+    it "has a self-consistent User-Agent and Sec-Ch-Ua" do
+      headers = described_class.browser_headers
+      ua = headers["User-Agent"]
+      sec_ch_ua = headers["Sec-Ch-Ua"]
+
+      chrome_version = ua.match(/Chrome\/(\d+)/)[1]
+      expect(sec_ch_ua).to include("\"Google Chrome\";v=\"#{chrome_version}\"")
+      expect(sec_ch_ua).to include("\"Chromium\";v=\"#{chrome_version}\"")
+    end
+
+    it "includes Not_A Brand in Sec-Ch-Ua" do
+      expect(headers["Sec-Ch-Ua"]).to include('"Not_A Brand"')
+    end
+
+    it "sets Sec-Ch-Ua-Mobile to desktop" do
+      expect(headers["Sec-Ch-Ua-Mobile"]).to eq("?0")
+    end
+  end
+
+  describe "randomness" do
+    it "returns different profiles across multiple calls" do
+      samples = Array.new(20) { described_class.random_user_agent }
+      unique = samples.uniq
+      expect(unique.size).to be >= 2
+    end
+  end
+end


### PR DESCRIPTION
Some font servers (e.g. fontopo.com) block automated requests without a realistic User-Agent header, causing Down::TimeoutError failures during CI formula health checks.

Add Fontist::Utils::UserAgent module with:
- Pool of 5 realistic Chrome profiles (macOS/Windows/Linux, Chrome 130-132)
- Random profile selection per download request
- Full browser-like headers: User-Agent, Sec-Ch-Ua, Sec-Ch-Ua-Platform, Sec-Fetch-*, Accept, Accept-Language, Cache-Control
- Self-consistent profiles (UA string matches platform + chrome version)

Integration:
- Utils::Downloader uses browser_headers as default, formula headers override
- CatalogManager uses random_user_agent for open-uri calls
- SilImporter uses random_user_agent for open-uri calls

30 tests pass (8 downloader + 22 user_agent).