### PR TITLE
Detect font type from magic bytes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,10 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in fontist.gemspec
 gemspec
 
+# TODO: Remove this fontisan pin after https://github.com/fontist/fontisan/pull/28
+# is merged and released.
+gem "fontisan", github: "fontist/fontisan", branch: "font-file-detection"
+
 gem "bundler"
 gem "openssl", "~> 3.0"
 gem "ostruct"

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in fontist.gemspec
 gemspec
 
-# TODO: Remove this fontisan pin after https://github.com/fontist/fontisan/pull/28
-# is merged and released.
-gem "fontisan", github: "fontist/fontisan", branch: "font-file-detection"
-
 gem "bundler"
 gem "openssl", "~> 3.0"
 gem "ostruct"

--- a/lib/fontist/collection_file.rb
+++ b/lib/fontist/collection_file.rb
@@ -49,10 +49,7 @@ module Fontist
         end
 
         collection
-      rescue Errors::FontFileError
-        # Already a FontFileError with a clean message we authored above
-        # (e.g. "File is not a recognized font collection"). Re-raise as-is
-        # so the message isn't double-wrapped into a Ruby #inspect string.
+      rescue Errors::FontIndexabilityValidationError
         raise
       rescue StandardError => e
         raise Errors::FontFileError,

--- a/lib/fontist/collection_file.rb
+++ b/lib/fontist/collection_file.rb
@@ -43,15 +43,20 @@ module Fontist
             "#{e.category}: #{e.message}"
           end.join("; ")
           # rubocop:disable Layout/LineLength
-          raise Errors::FontFileError,
+          raise Errors::FontIndexabilityValidationError,
                 "Font collection failed indexability validation (first font): #{error_messages}"
           # rubocop:enable Layout/LineLength
         end
 
         collection
+      rescue Errors::FontFileError
+        # Already a FontFileError with a clean message we authored above
+        # (e.g. "File is not a recognized font collection"). Re-raise as-is
+        # so the message isn't double-wrapped into a Ruby #inspect string.
+        raise
       rescue StandardError => e
         raise Errors::FontFileError,
-              "Font collection could not be loaded: #{e.inspect}."
+              "Font collection could not be loaded: #{e.message}"
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 

--- a/lib/fontist/errors.rb
+++ b/lib/fontist/errors.rb
@@ -20,6 +20,12 @@ module Fontist
 
     class FontFileError < GeneralError; end
 
+    # Raised when a font is structurally readable but fails the indexability
+    # profile (missing required tables, incomplete name records, etc.).
+    # Distinct from FontFileError so callers can tell "we don't recognise this
+    # file" apart from "this file is a font but unusable as an index entry".
+    class FontIndexabilityValidationError < FontFileError; end
+
     class FontExtractError < GeneralError; end
 
     class FontistVersionError < GeneralError; end

--- a/lib/fontist/font_file.rb
+++ b/lib/fontist/font_file.rb
@@ -150,26 +150,9 @@ module Fontist
       end
       # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
 
-      # rubocop:disable Metrics/MethodLength
       def detect_font_format(path)
-        # Open file and check SFNT version to determine actual format
-        File.open(path, "rb") do |io|
-          signature = io.read(4)
-          io.rewind
-
-          case signature
-          when "\x00\x01\x00\x00", "true"
-            "ttf"
-          when "OTTO"
-            "otf"
-          when "wOFF"
-            "woff"
-          when "wOF2"
-            "woff2"
-          else
-            "unknown"
-          end
-        end
+        format = Fontisan::FontLoader.detect_format(path)
+        format ? format.to_s : "unknown"
       rescue StandardError
         "unknown"
       end

--- a/lib/fontist/system_index.rb
+++ b/lib/fontist/system_index.rb
@@ -653,32 +653,18 @@ spinner_index = nil)
     # `SauberScript.ttc` inside its private FontServices framework). Trusting
     # the extension causes such files to be routed through the collection
     # parser, which correctly rejects them, producing spurious "not recognized"
-    # warnings. The fallback to the extension preserves the previous behavior
-    # for files we cannot open (permission errors, etc.).
+    # warnings.
     def gather_fonts(path)
-      format = detect_font_format(path)
-
-      case format
-      when :ttc, :otc, :dfont
+      case Fontisan::FontLoader.detect_format(path)
+      when :ttc, :otc
         detect_collection_fonts(path)
       when :ttf, :otf, :woff, :woff2
         detect_file_font(path)
       else
         print_recognition_error(Errors::UnknownFontTypeError.new(path), path)
       end
-    end
-
-    def detect_font_format(path)
-      Fontisan::FontLoader.detect_format(path) || extension_format(path)
-    rescue Errno::ENOENT, Errno::EACCES
-      extension_format(path)
-    end
-
-    def extension_format(path)
-      ext = File.extname(path).gsub(/^\./, "").downcase
-      return nil if ext.empty?
-
-      ext.to_sym
+    rescue Errno::ENOENT, Errno::EACCES, IOError => e
+      print_recognition_error(Errors::FontFileError.new(e.message), path)
     end
 
     def print_validation_error(exception, path)

--- a/lib/fontist/system_index.rb
+++ b/lib/fontist/system_index.rb
@@ -1,4 +1,5 @@
 require "paint"
+require "fontisan"
 
 module Fontist
   # Statistics tracking for index building (thread-safe)
@@ -630,15 +631,12 @@ spinner_index = nil)
       return if excluded?(path)
 
       gather_fonts(path)
+    rescue Errors::FontIndexabilityValidationError => e
+      stats&.record_validation_failure
+      print_validation_error(e, path)
     rescue Errors::FontFileError => e
-      # Check if this is a validation failure
-      if e.message.include?("indexability validation")
-        stats&.record_validation_failure
-        print_validation_error(e, path)
-      else
-        stats&.record_error
-        print_recognition_error(e, path)
-      end
+      stats&.record_error
+      print_recognition_error(e, path)
     end
 
     def excluded?(path)
@@ -649,15 +647,38 @@ spinner_index = nil)
       @excluded_fonts ||= YAML.load_file(Fontist.excluded_fonts_path)
     end
 
+    # Dispatch a file to the file-font or collection parser based on its actual
+    # magic bytes, not its extension. Some vendors ship files with misleading
+    # extensions (notably macOS ships a single OpenType-CFF font as
+    # `SauberScript.ttc` inside its private FontServices framework). Trusting
+    # the extension causes such files to be routed through the collection
+    # parser, which correctly rejects them, producing spurious "not recognized"
+    # warnings. The fallback to the extension preserves the previous behavior
+    # for files we cannot open (permission errors, etc.).
     def gather_fonts(path)
-      case File.extname(path).gsub(/^\./, "").downcase
-      when "ttf", "otf", "woff", "woff2"
-        detect_file_font(path)
-      when "ttc", "otc"
+      format = detect_font_format(path)
+
+      case format
+      when :ttc, :otc, :dfont
         detect_collection_fonts(path)
+      when :ttf, :otf, :woff, :woff2
+        detect_file_font(path)
       else
         print_recognition_error(Errors::UnknownFontTypeError.new(path), path)
       end
+    end
+
+    def detect_font_format(path)
+      Fontisan::FontLoader.detect_format(path) || extension_format(path)
+    rescue Errno::ENOENT, Errno::EACCES
+      extension_format(path)
+    end
+
+    def extension_format(path)
+      ext = File.extname(path).gsub(/^\./, "").downcase
+      return nil if ext.empty?
+
+      ext.to_sym
     end
 
     def print_validation_error(exception, path)

--- a/spec/fontist/system_index_spec.rb
+++ b/spec/fontist/system_index_spec.rb
@@ -118,6 +118,15 @@ RSpec.describe Fontist::SystemIndex do
       expect(instance.fonts).not_to be_empty
       expect(instance.fonts.first.path).to eq(masquerading_path)
     end
+
+    it "dispatches via magic-byte detection, not file extension" do
+      expect(Fontisan::FontLoader)
+        .to receive(:detect_format).with(masquerading_path)
+        .once.and_call_original
+
+      instance.find("Overpass Mono", nil)
+      expect(instance.fonts.first.path).to eq(masquerading_path)
+    end
   end
 
   context "preferred family index" do

--- a/spec/fontist/system_index_spec.rb
+++ b/spec/fontist/system_index_spec.rb
@@ -119,13 +119,52 @@ RSpec.describe Fontist::SystemIndex do
       expect(instance.fonts.first.path).to eq(masquerading_path)
     end
 
-    it "dispatches via magic-byte detection, not file extension" do
-      expect(Fontisan::FontLoader)
-        .to receive(:detect_format).with(masquerading_path)
-        .once.and_call_original
-
+    it "indexes the font despite .ttc extension signaling collection" do
+      # The file has .ttc extension (collection) but magic bytes say OTF (single).
+      # Verify it is indexed as a single font, not rejected as an invalid collection.
       instance.find("Overpass Mono", nil)
-      expect(instance.fonts.first.path).to eq(masquerading_path)
+      expect(instance.fonts.size).to eq(1)
+      expect(instance.fonts.first.full_name).to include("Overpass Mono")
+    end
+  end
+
+  context "when a TTC collection is mislabeled with a single-font extension" do
+    let(:tmp_dir) { create_tmp_dir }
+    let(:mislabeled_ttc_path) do
+      path = File.join(tmp_dir, "FakeSingle.otf")
+      FileUtils.cp(examples_font_path("Times.ttc"), path)
+      path
+    end
+    let(:index_path) { File.join(tmp_dir, "system_index.yml") }
+    let(:instance) do
+      Fontist::SystemIndexFontCollection.new.tap do |x|
+        x.set_path(index_path)
+        x.set_path_loader(-> { [mislabeled_ttc_path] })
+      end
+    end
+
+    it "indexes all fonts from the collection based on magic bytes" do
+      instance.find("Times", nil)
+      expect(instance.fonts.size).to be > 1
+      instance.fonts.each { |f| expect(f.path).to eq(mislabeled_ttc_path) }
+    end
+  end
+
+  context "when format detection encounters an I/O error" do
+    let(:tmp_dir) { create_tmp_dir }
+    let(:missing_path) { File.join(tmp_dir, "vanished.ttf") }
+    let(:index_path) { File.join(tmp_dir, "system_index.yml") }
+    let(:instance) do
+      Fontist::SystemIndexFontCollection.new.tap do |x|
+        x.set_path(index_path)
+        x.set_path_loader(-> { [missing_path] })
+      end
+    end
+
+    it "prints a recognition error without raising" do
+      expect(Fontist.ui).to receive(:error).with(/not recognized as a font file/)
+      expect { instance.find("anything", nil) }.not_to raise_error
+      expect(instance.fonts).to be_empty
     end
   end
 
@@ -264,21 +303,24 @@ RSpec.describe Fontist::SystemIndex do
       end
 
       it "filters out fonts with incomplete metadata" do
-        # Mock a font file that returns nil for required fields
-        allow(Fontist::FontFile).to receive(:from_path).and_return(
-          double(
-            full_name: nil,
-            family: nil,
-            subfamily: "Regular",
-            preferred_family: nil,
-            preferred_subfamily: nil,
-          ),
-        )
+        # Create a minimal TTF binary with no name table.
+        # This exercises the real code path: detect_format → FontFile.from_path
+        # → extract_names_from_font → parse_font → incomplete metadata check.
+        # No stubbing — the font genuinely produces nil metadata.
+        no_names_path = File.join(tmp_dir, "no_names.ttf")
+        sfnt_header = [0x00010000, 1, 16, 0, 0].pack("Nnnnn")
+        table_dir = ["head".b, 0, 28, 54].pack("a4NNN")
+        File.binwrite(no_names_path, sfnt_header + table_dir + ("\x00" * 54))
+
+        no_names_instance = Fontist::SystemIndexFontCollection.new.tap do |x|
+          x.set_path(index_path)
+          x.set_path_loader(-> { [no_names_path] })
+        end
 
         expect(Fontist.ui).to receive(:error).with(/Skipping font with incomplete metadata/)
 
-        instance.build
-        expect(instance.fonts).to be_empty
+        no_names_instance.build
+        expect(no_names_instance.fonts).to be_empty
       end
     end
 

--- a/spec/fontist/system_index_spec.rb
+++ b/spec/fontist/system_index_spec.rb
@@ -92,6 +92,34 @@ RSpec.describe Fontist::SystemIndex do
     end
   end
 
+  context "when a font file's extension misrepresents its content" do
+    # Regression for the SauberScript.ttc case: Apple's private FontServices
+    # framework ships a single OpenType-CFF font (magic 'OTTO') with a .ttc
+    # extension. The index dispatcher must trust the magic bytes, not the
+    # extension, so the font is indexed instead of producing a "not
+    # recognized as a font file" warning.
+    let(:tmp_dir) { create_tmp_dir }
+    let(:masquerading_path) do
+      path = File.join(tmp_dir, "SauberScript.ttc")
+      FileUtils.cp(examples_font_path("overpass-mono-regular.otf"), path)
+      path
+    end
+    let(:index_path) { File.join(tmp_dir, "system_index.yml") }
+    let(:instance) do
+      Fontist::SystemIndexFontCollection.new.tap do |x|
+        x.set_path(index_path)
+        x.set_path_loader(-> { [masquerading_path] })
+      end
+    end
+
+    it "indexes the font based on its actual format" do
+      expect(Fontist.ui).not_to receive(:error)
+      instance.find("Overpass Mono", nil)
+      expect(instance.fonts).not_to be_empty
+      expect(instance.fonts.first.path).to eq(masquerading_path)
+    end
+  end
+
   context "preferred family index" do
     let(:tmp_dir) { Fontist.temp_fontist_path }
     let(:font_file) do


### PR DESCRIPTION
fixes #469 

## Prerequisites

Need to release https://github.com/fontist/fontisan/pull/28 before merging this one.

## Root cause

Examined the file directly:

```bash
$ xxd /System/Library/PrivateFrameworks/FontServices.framework/Resources/Fonts/Subsets/SauberScript.ttc | head -1
  00000000: 4f54 544f 000c 0080 0003 00b8 4346 4620   OTTO........CFF
```

First 4 bytes are OTTO (`SFNT_VERSION_OTTO` per `fontisan/lib/fontisan/constants.rb:26`) — i.e. a single OpenType font with CFF outlines. Not a TTC. `Fontisan::FontLoader.collection?`
correctly returns false.

To confirm this is isolated, I scanned all .ttc files in that Apple directory:

120 files start with ttcf (74746366)   ← real TTCs
&nbsp; &nbsp; 1 file  starts with OTTO (4f54544f)  ← SauberScript.ttc — misnamed by Apple

So this is one specific Apple-shipped file with a wrong extension. Other `.ttcs` on the system parse fine.

## Before this fix

```bash
$ bundle exec fontist install "arial"
Building font index (563 fonts found, this may take a while...)
Scanning fonts: 50/563...
Scanning fonts: 100/563...
Scanning fonts: 150/563...
Scanning fonts: 200/563...
Scanning fonts: 250/563...
Scanning fonts: 300/563...
Scanning fonts: 350/563...
Scanning fonts: 400/563...
Scanning fonts: 450/563...
Scanning fonts: 500/563...
Scanning fonts: 550/563...
#<Fontist::Errors::FontFileError: Font collection could not be loaded: #<Fontist::Errors::FontFileError: File is not a recognized font collection (TTC/OTC/dfont)>.>
Warning: File at /System/Library/PrivateFrameworks/FontServices.framework/Resources/Fonts/Subsets/SauberScript.ttc not recognized as a font file.
Scanning fonts: 563/563...
Fonts found at:
- /System/Library/Fonts/Supplemental/Arial Bold Italic.ttf
- /System/Library/Fonts/Supplemental/Arial Bold.ttf
- /System/Library/Fonts/Supplemental/Arial Italic.ttf
- /System/Library/Fonts/Supplemental/Arial.ttf
```

## After this fix

```bash
$ bundle exec fontist install "arial"
Building font index (563 fonts found, this may take a while...)
Scanning fonts: 50/563...
Scanning fonts: 100/563...
Scanning fonts: 150/563...
Scanning fonts: 200/563...
Scanning fonts: 250/563...
Scanning fonts: 300/563...
Scanning fonts: 350/563...
Scanning fonts: 400/563...
Scanning fonts: 450/563...
Scanning fonts: 500/563...
Scanning fonts: 550/563...
WARNING: File 'SauberScript.ttc' has collection extension '.ttc' but appears to be a single font (.otf). The file will be indexed, but consider renaming for clarity.
Scanning fonts: 563/563...
Font index built: 1650 fonts indexed in 0.4s
Fonts found at:
- /System/Library/Fonts/Supplemental/Arial Bold Italic.ttf
- /System/Library/Fonts/Supplemental/Arial Bold.ttf
- /System/Library/Fonts/Supplemental/Arial Italic.ttf
- /System/Library/Fonts/Supplemental/Arial.ttf
```