### PR TITLE
Fix font not found after install: reset index and find_styles cache

### DIFF
--- a/lib/fontist/manifest.rb
+++ b/lib/fontist/manifest.rb
@@ -215,10 +215,10 @@ location: nil)
           installed_any = true
         end
       end
-      # Only reset fontist index (not system index) if we actually installed fonts
       if installed_any
-        # Reset only the fontist font cache, not system fonts
         Fontist::SystemFont.reset_fontist_font_paths_cache
+        Fontist::Indexes::FontistIndex.instance.reset_cache
+        Fontist::SystemFont.reset_find_styles_cache
       end
       to_response
     end


### PR DESCRIPTION
## Problem

After `Manifest#install` installs fonts, subsequent font lookups fail to find them. This causes `MissingFontError` in callers like metanorma's `location_manifest` even though the font was just installed.

Reported in #473.

## Root Cause

`Manifest#install` only reset the `fontist_font_paths_cache` (a Dir.glob cache), but NOT:
1. The `FontistIndex` cache (singleton that maps font names to installed paths)
2. The `find_styles_cache` (caches `nil` results for missing fonts)

The `find_styles_cache` is particularly harmful: during `Manifest.from_hash` → `to_response(locations: false)`, it caches `nil` for each missing font. After installation, the stale `nil` entries persist — `Manifest#install` → `to_response` and any subsequent `Manifest.from_hash(..., locations: true)` call still see the cached `nil` and think the font is missing.

## Fix

After font installation, reset all three caches:
- `Fontist::SystemFont.reset_fontist_font_paths_cache` (existing)
- `Fontist::Indexes::FontistIndex.instance.reset_cache` (new)
- `Fontist::SystemFont.reset_find_styles_cache` (new)

This ensures the FontistIndex re-scans the installed fonts directory, and the find_styles cache is cleared so fresh lookups are performed.

## Testing

All 1418 tests pass (0 failures).

Fixes #473