### PR TITLE
Clear find_styles cache after manifest install

### DIFF
--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "down", "~> 5.0"
   spec.add_dependency "excavate", "~> 1.0", ">= 1.0.3"
-  spec.add_dependency "fontisan", "~> 0.2", ">= 0.2.16"
+  spec.add_dependency "fontisan", "~> 0.2", ">= 0.2.17"
   spec.add_dependency "fuzzy_match", "~> 2.1"
   spec.add_dependency "git", "> 1.0"
   spec.add_dependency "json", "~> 2.0"

--- a/lib/fontist/manifest.rb
+++ b/lib/fontist/manifest.rb
@@ -215,10 +215,9 @@ location: nil)
           installed_any = true
         end
       end
-      # Only reset fontist index (not system index) if we actually installed fonts
       if installed_any
-        # Reset only the fontist font cache, not system fonts
         Fontist::SystemFont.reset_fontist_font_paths_cache
+        Fontist::SystemFont.reset_find_styles_cache
       end
       to_response
     end


### PR DESCRIPTION
## Problem

After `Manifest#install` installs fonts, subsequent lookups via `Manifest.from_hash(..., locations: true)` fail with `MissingFontError` because the `find_styles_cache` holds stale `nil` entries from the initial `Manifest.from_hash` call.

Reported in #473.

## Root Cause

1. `Manifest.from_hash(manifest)` → `to_response(locations: false)` populates `find_styles_cache` with `nil` for each missing font
2. `.install(confirmation: "yes")` installs the fonts — `FontInstaller` calls `add_font` which updates the FontistIndex in-memory
3. `to_response` at end of `install` uses `with_performance_optimizations` which re-enables the cache — stale `nil` entries persist
4. Later, metanorma's `location_manifest` calls `Manifest.from_hash(..., locations: true)` → cache still has stale `nil` → `MissingFontError`

## Fix

Clear `find_styles_cache` after installation. The FontistIndex is already up-to-date (updated in-place by `add_font` during each font install), so only the lookup cache needs clearing.

## Testing

All 1418 tests pass (0 failures).

Fixes #473