### PR TITLE
feat(docs): per-page OG tags, sitemap, robots.txt, trailing-slash fix

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,20 @@
-import { defineConfig } from "vitepress";
+import { defineConfig, type HeadConfig } from "vitepress";
 import { fileURLToPath, URL } from "node:url";
+
+const SITE_ORIGIN = "https://www.fontist.org";
+const BASE_PATH = "/fontist/";
+const DEFAULT_DESCRIPTION =
+  "Fontist brings cross-platform font management to the command line for Windows, Linux, and macOS. Free and open source.";
+const DEFAULT_OG_IMAGE = `${SITE_ORIGIN}/og-image.png`;
+
+// Map a page's source path to its canonical public URL (origin + base + clean path).
+function pathToUrl(relativePath: string): string {
+  const bare = relativePath.replace(/\.md$/, "").replace(/\\/g, "/");
+  if (bare === "index") return `${SITE_ORIGIN}${BASE_PATH}`;
+  if (bare.endsWith("/index"))
+    return `${SITE_ORIGIN}${BASE_PATH}${bare.slice(0, -6)}/`;
+  return `${SITE_ORIGIN}${BASE_PATH}${bare}`;
+}
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -22,6 +37,11 @@ export default defineConfig({
 
   lastUpdated: true,
 
+  // https://vitepress.dev/reference/site-config#sitemap
+  sitemap: {
+    hostname: SITE_ORIGIN,
+  },
+
   // Base path for deployment (e.g., /fontist/ for fontist.org/fontist/)
   base: process.env.BASE_PATH || "/fontist/",
 
@@ -38,18 +58,30 @@ export default defineConfig({
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:title", content: "Fontist" }],
-    [
-      "meta",
-      {
-        property: "og:description",
-        content:
-          "Fontist brings cross-platform font management to the command line for Windows, Linux, and macOS.",
-      },
-    ],
-    ["meta", { property: "og:image", content: "/logo-full.svg" }],
-    ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
+
+  // Per-page og:* and twitter:* tags are derived from each page's frontmatter.
+  // https://vitepress.dev/reference/site-config#transformhead
+  transformHead(ctx) {
+    const { pageData } = ctx;
+    const url = pathToUrl(pageData.relativePath);
+    const title = pageData.title || "Fontist";
+    const description = pageData.description || DEFAULT_DESCRIPTION;
+    const image = pageData.frontmatter.image || DEFAULT_OG_IMAGE;
+
+    const tags: HeadConfig[] = [
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { property: "og:url", content: url }],
+      ["meta", { property: "og:image", content: image }],
+      ["meta", { name: "twitter:card", content: "summary_large_image" }],
+      ["meta", { name: "twitter:title", content: title }],
+      ["meta", { name: "twitter:description", content: description }],
+      ["meta", { name: "twitter:image", content: image }],
+    ];
+
+    return tags;
+  },
 
   // https://vitepress.dev/reference/default-theme-config
   themeConfig: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "vitepress dev",
-    "build": "vitepress build",
+    "build": "vitepress build && node scripts/post-build.mjs",
     "preview": "vitepress preview",
     "format": "prettier -w ."
   },

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.fontist.org/fontist/sitemap.xml

--- a/docs/scripts/post-build.mjs
+++ b/docs/scripts/post-build.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Post-build fixes for GitHub Pages subpath deployment.
+//
+// 1. Dirify: convert VitePress file-style output (foo.html) to directory-style
+//    (foo/index.html) so GitHub Pages resolves BOTH /foo and /foo/. Without
+//    this, /foo/ 404s because foo.html is a file, not a directory.
+//
+// 2. Sitemap base: insert the deployment base path into sitemap.xml URLs.
+//    VitePress omits `base` from sitemap route paths (and ignores the path
+//    portion of `sitemap.hostname`), so the generated URLs point at the origin
+//    root instead of the subsite. We rewrite each <loc> to include the base.
+//
+// Idempotent. Kept at the dist root: index.html (site root), 404.html (GHP 404 page).
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const DIST = ".vitepress/dist";
+const HTML = ".html";
+const KEEP_AT_ROOT = new Set(["index.html", "404.html"]);
+// Subsite identity — must match config.ts base and the real deployment URL.
+const ORIGIN = "https://www.fontist.org";
+const BASE = "fontist"; // path segment under ORIGIN (no slashes)
+
+let moved = 0;
+let skipped = 0;
+
+function dirify(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      dirify(full);
+      continue;
+    }
+    if (!entry.endsWith(HTML)) continue;
+    if (entry === "index.html") continue; // already directory-style
+    if (dir === DIST && KEEP_AT_ROOT.has(entry)) {
+      skipped++; // root index.html / 404.html stay put
+      continue;
+    }
+    const name = entry.slice(0, -HTML.length);
+    const targetDir = join(dir, name);
+    const targetIndex = join(targetDir, "index.html");
+    if (existsSync(targetIndex)) {
+      console.warn(`[post-build] skip ${full.replace(DIST + "/", "")}: target exists`);
+      skipped++;
+      continue;
+    }
+    mkdirSync(targetDir, { recursive: true });
+    renameSync(full, targetIndex);
+    moved++;
+  }
+}
+
+function fixSitemapBase() {
+  const sitemap = `${DIST}/sitemap.xml`;
+  if (!existsSync(sitemap)) return false;
+  let xml = readFileSync(sitemap, "utf8");
+  // Insert BASE after the origin unless the path already starts with BASE
+  // (VitePress emits the homepage route as "/<base>"; other routes omit it).
+  const originPattern = new RegExp(
+    `(<loc>${ORIGIN.replaceAll("/", "\\/")}\\/)(?!${BASE}(\\/|$))`,
+    "g",
+  );
+  xml = xml.replace(originPattern, `$1${BASE}/`);
+  writeFileSync(sitemap, xml);
+  return true;
+}
+
+dirify(DIST);
+const sitemapFixed = fixSitemapBase();
+console.log(
+  `[post-build] dirified ${moved} route(s), kept ${skipped} at root; sitemap ${sitemapFixed ? "rewritten with /" + BASE + "/" : "absent (skipped)"}`,
+);


### PR DESCRIPTION
Applies the fontist.org SEO + routing fixes (PRs #37/#38/#40) to the **fontist** subsite so it matches the greater setup.

## Changes

| Area | Before | After |
|---|---|---|
| **Trailing-slash URLs** | `/fontist/cli/install/` → **404** (file-route) | `/fontist/cli/install/` → **200** (dirified to `cli/install/index.html`) |
| **og:image** | `/logo-full.svg` (relative — invalid for social crawlers) | `https://www.fontist.org/og-image.png` (shared absolute PNG) |
| **og:title / og:description** | site-wide static | per-page via `transformHead` |
| **og:url** | absent | per-page canonical, base-aware (`https://www.fontist.org/fontist/...`) |
| **sitemap.xml** | absent (404) | generated; post-build inserts the `/fontist/` base (VitePress omits `base` from sitemap routes) |
| **robots.txt** | absent (404) | `public/robots.txt` pointing at the subsite sitemap |

## Files

- `docs/.vitepress/config.ts` — `transformHead`, `sitemap`, removed static og/twitter tags, added helpers.
- `docs/scripts/post-build.mjs` — **new**: dirify file-routes + rewrite sitemap URLs to include the base. Idempotent.
- `docs/public/robots.txt` — **new**.
- `docs/package.json` — `build` now runs `vitepress build && node scripts/post-build.mjs`. No new deps (uses Node builtins only).

## Why the post-build script

VitePress `cleanUrls` builds `foo.md → foo.html`, but GitHub Pages resolves `/foo/` as `foo/index.html` (a directory) → 404. Moving each non-index `*.html` to `<name>/index.html` makes both URL forms resolve. The same script also fixes the sitemap: VitePress omits `base` from sitemap route paths (and ignores the path component of `sitemap.hostname`), so the generated URLs point at the origin root instead of `/fontist/`; the script rewrites each `<loc>` to include the base.

## Verification (local)

- `npm run build` → `[post-build] dirified 37 route(s), kept 1 at root; sitemap rewritten with /fontist/`.
- `cli/install/index.html` exists, `cli/install.html` is gone.
- Sitemap: `https://www.fontist.org/fontist/api/errors`, homepage `https://www.fontist.org/fontist/`, no doubled segments.
- Per-page OG on `cli/install/index.html`: `og:title="fontist install"`, `og:url="https://www.fontist.org/fontist/cli/install"`, `og:image="https://www.fontist.org/og-image.png"`.
- Idempotent: re-running post-build dirifies 0 routes and doesn't double-prefix sitemap URLs.

## Not in scope

- The `check:subsite-links` guard from fontist.org isn't included here: VitePress already auto-externalizes markdown/config cross-site links with `target="_blank"`, so there are no current offenders and a generic check would false-positive on the subsite's own internal `/*` links.
- JSON-LD structured data (fontist.org has it for blog posts; this subsite has no blog).
