### PR TITLE
fix(docs): Spectral display font + override VitePress Inter globally

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
       "link",
       {
         rel: "stylesheet",
-        href: "https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..700;1,6..72,300..700&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap",
+        href: "https://fonts.googleapis.com/css2?family=Spectral:ital,opsz,wght@0,7..72,200..800;1,7..72,200..800&family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@300;400;500;600&display=swap",
       },
     ],
   ],

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -47,9 +47,13 @@
   --vp-sidebar-bg-color: var(--spec-paper);
 
   /* Type */
-  --spec-font-display: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --spec-font-display: "Spectral", Georgia, serif;
   --spec-font-body: "IBM Plex Sans", -apple-system, system-ui, sans-serif;
   --spec-font-mono: "IBM Plex Mono", ui-monospace, "JetBrains Mono", monospace;
+
+  /* Override VitePress's default Inter with our specimen fonts everywhere */
+  --vp-font-family-base: var(--spec-font-body);
+  --vp-font-family-mono: var(--spec-font-mono);
 
   /* Buttons */
   --vp-button-brand-border: var(--spec-rose);
@@ -361,7 +365,7 @@ html.dark body::before {
   width: 48px;
   margin: 3em auto;
 }
-/* Drop cap — rose Newsreader italic on the first paragraph of content pages */
+/* Drop cap — rose Spectral italic on the first paragraph of content pages */
 .vp-doc > p:first-of-type::first-letter {
   font-family: var(--spec-font-display);
   font-style: italic;


### PR DESCRIPTION
Two critical font fixes:

1. **Display font**: Newsreader → Spectral (Production Type variable serif, opsz 7-72). More personality at display sizes, better italics, proper optical sizing.

2. **VitePress Inter override**: VitePress bundles Inter and applies it via `--vp-font-family-base` to every element. Without overriding this variable, nav/sidebar/footer/search all fall back to Inter instead of IBM Plex Sans. Now setting both `--vp-font-family-base` and `--vp-font-family-mono` in `:root`.