### PR TITLE
feat: update fontisan to ~> 0.4

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -588,15 +588,10 @@ html.dark .vp-doc [class*="language-"] {
 .code-content .comment { color: rgba(236, 223, 208, 0.45) !important; }
 .code-content .line { padding: 1px 0; }
 
-/* ── VPFeatures ───────────────────────────────────────────────── */
+/* ── VPFeatures — only style cards, DON'T override grid layout ─── */
+/* VitePress renders responsive columns on .item.grid-N (child of .items).
+   Overriding .items as a grid fights VitePress's own engine. Only style .box. */
 .VPFeatures .container { padding-top: 2rem; }
-.VPFeatures .items {
-  display: grid !important;
-  gap: 1px !important;
-  background: var(--spec-rule) !important;
-}
-@media (min-width: 512px) { .VPFeatures .items { grid-template-columns: repeat(2, 1fr) !important; } }
-@media (min-width: 768px) { .VPFeatures .items { grid-template-columns: repeat(3, 1fr) !important; } }
 
 .VPFeature {
   background: transparent !important;
@@ -604,17 +599,17 @@ html.dark .vp-doc [class*="language-"] {
   border-radius: 0 !important;
   box-shadow: none !important;
 }
-/* Target the inner .box — VitePress renders the visible card here, not on .VPFeature */
 .VPFeature .box {
   background: var(--spec-paper) !important;
-  border: none !important;
+  border: 1px solid var(--spec-rule) !important;
   border-radius: 0 !important;
   box-shadow: none !important;
   height: 100% !important;
-  transition: background 0.2s ease !important;
+  transition: border-color 0.2s ease, background 0.2s ease !important;
 }
 .VPFeature .box:hover {
   background: var(--spec-paper-deep) !important;
+  border-color: var(--spec-rose) !important;
 }
 .VPFeature .title {
   font-family: var(--spec-font-display) !important;
@@ -628,3 +623,6 @@ html.dark .vp-doc [class*="language-"] {
   line-height: 1.55 !important;
   color: var(--spec-ink-soft) !important;
 }
+html.dark .VPFeature .box { background: var(--spec-paper) !important; }
+html.dark .VPFeature .box:hover { background: var(--spec-paper-deep) !important; }
+

--- a/fontist.gemspec
+++ b/fontist.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "down", "~> 5.0"
   spec.add_dependency "excavate", "~> 1.0", ">= 1.0.3"
-  spec.add_dependency "fontisan", "~> 0.2", ">= 0.2.17"
+  spec.add_dependency "fontisan", "~> 0.4", ">= 0.4.9"
   spec.add_dependency "fuzzy_match", "~> 2.1"
   spec.add_dependency "git", "> 1.0"
   spec.add_dependency "json", "~> 2.0"


### PR DESCRIPTION
Updates fontisan dependency from ~> 0.2, >= 0.2.17 to ~> 0.4, >= 0.4.9.

Fontisan 0.4.x removed the Audit subsystem (moved to ucode). All 1422 fontist specs pass with fontisan 0.4.9.